### PR TITLE
Exclude additional DEVICE_TYPE for Neoplug

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.debug(NeoHubJson)
 
     for device in NeoHubJson['devices']:
-        if device['DEVICE_TYPE'] != 6:
+        if device['DEVICE_TYPE'] not in [0,6]:
             name = device['device']
             tmptempfmt = device['TEMPERATURE_FORMAT']
             if (tmptempfmt == False) or (tmptempfmt.upper() == "C"):


### PR DESCRIPTION
My Neoplug (or rather, one I set up a couple of years back and haven't used since) is showing up as DEVICE_TYPE = 0
This small PR also excludes these when discovering entities.
resolves #40 