### PR TITLE
update climate.py to include target temp when idle

### DIFF
--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -185,7 +185,7 @@ class HeatmiserNeostat(ClimateEntity):
             self._support_flags = SUPPORT_FLAGS | SUPPORT_TARGET_TEMPERATURE_RANGE
         elif hvac_mode == HVAC_MODE_FAN_ONLY:
             self._hvac_mode = HVAC_MODE_FAN_ONLY
-            self._support_flags = SUPPORT_FLAGS
+            self._support_flags = SUPPORT_FLAGS | SUPPORT_TARGET_TEMPERATURE
         else:
             _LOGGER.error("Unsupported hvac mode: %s", hvac_mode)
             return


### PR DESCRIPTION
 added SUPPORT_TARGET_TEMPERATURE supported feature to HVAC_MODE_FAN_ONLY so you can access temperature attributes when idle. Think this was inadvertently removed as part of PR[#45](https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/75)