### PR TITLE
Further performance improvements

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -1,10 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+import logging
+from datetime import timedelta
+import async_timeout
+
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from homeassistant.const import CONF_HOST,CONF_PORT
 
 from neohubapi.neohub import NeoHub
-from .const import DOMAIN, HUB
+from .const import DOMAIN, HUB, COORDINATOR
 
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
     """Set up Heamiser Neo components."""
@@ -21,6 +30,35 @@ async def async_setup_entry(hass, entry):
     hub = NeoHub(host, port)
     hass.data[DOMAIN][HUB] = hub
 
+    async def async_update_data():
+        """Fetch data from the Hub all at once and make it available for
+           all thermostats.
+        """
+        _LOGGER.info(f"Executing update_data()")
+        
+        async with async_timeout.timeout(30):
+            _, devices_data = await hub.get_live_data()
+            system_data = await hub.get_system()
+            
+            #_LOGGER.debug(f"system_data: {system_data}")
+            _LOGGER.debug(f"devices_data: {devices_data}")
+            
+            return (devices_data, system_data)
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        # Name of the data. For logging purposes.
+        name="neostat",
+        update_method=async_update_data,
+        # Polling interval. Will only be polled if there are subscribers.
+        update_interval=timedelta(seconds=30)
+    )
+
+    hass.data[DOMAIN][COORDINATOR] = coordinator
+
+    await coordinator.async_config_entry_first_refresh()
+    
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "climate")
     )

--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -32,7 +32,7 @@ async def async_setup_entry(hass, entry):
 
     async def async_update_data():
         """Fetch data from the Hub all at once and make it available for
-           all thermostats.
+           all devices.
         """
         _LOGGER.info(f"Executing update_data()")
         

--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from neohubapi.neohub import NeoHub, NeoStat, HCMode
-from .const import DOMAIN, HUB, COORDINATOR
+from .const import DOMAIN, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -10,8 +10,6 @@ Heatmiser NeoStat control via Heatmiser Neo-hub
 
 import logging
 import asyncio
-from datetime import timedelta
-import async_timeout
  
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
@@ -35,12 +33,13 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from neohubapi.neohub import NeoHub, NeoStat, HCMode
-from .const import DOMAIN, HUB
+from .const import DOMAIN, HUB, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
 
 
 SUPPORT_FLAGS = 0
+THERMOSTATS = 'thermostats'
 
 # This should be in the neohubapi.neohub enums code
 import enum
@@ -59,42 +58,16 @@ hvac_mode_mapping = {
 
 async def async_setup_entry(hass, entry, async_add_entities):
 
-    hub: NeoHub = hass.data[DOMAIN][HUB]
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
-    async def async_update_data():
-        """Fetch data from the Hub all at once and make it available for
-           all thermostats.
-        """
-        _LOGGER.info(f"Executing update_data()")
-        
-        async with async_timeout.timeout(30):
-            _, devices_data = await hub.get_live_data()
-            system_data = await hub.get_system()
-            #_LOGGER.debug(f"system_data: {system_data}")
-            
-            stats = {stat.name : stat for stat in devices_data['thermostats']}
-            _LOGGER.debug(f"stats: {stats}")
-            
-            return (stats, system_data)
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        # Name of the data. For logging purposes.
-        name="neostat",
-        update_method=async_update_data,
-        # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(seconds=30)
-    )
-
-    await coordinator.async_config_entry_first_refresh()
-
-    (thermostats, system_data) = coordinator.data
-
+    (devices_data, system_data) = coordinator.data
+    thermostats = {device.name : device for device in devices_data[THERMOSTATS]}
+    
     temperature_unit = system_data.CORF
     temperature_step = 1.0 if system_data.HUB_TYPE == 1 or system_data.HUB_VERSION < 2135 else 0.5
 
     entities = [NeoStatEntity(thermostat, temperature_unit, temperature_step, coordinator) for thermostat in thermostats.values()]
+    
     _LOGGER.info(f"Adding Thermostats: {entities}")
     async_add_entities(entities, True)
     
@@ -118,7 +91,8 @@ class NeoStatEntity(CoordinatorEntity, ClimateEntity):
     def data(self):
         """Helper to get the data for the current thermostat. """
         (devices, _) = self._coordinator.data
-        return devices[self.name]
+        thermostats = {device.name : device for device in devices[THERMOSTATS]}
+        return thermostats[self.name]
         
     @property
     def supported_features(self):

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -4,7 +4,7 @@
 DOMAIN = "heatmiserneo"
 
 HUB = "Hub"
+COORDINATOR = "Coordinator"
 
 DEFAULT_HOST = "Neo-Hub"
 DEFAULT_PORT = 4242
-

--- a/custom_components/heatmiserneo/manifest.json
+++ b/custom_components/heatmiserneo/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": [],
   "codeowners": ["MindrustUK"],
   "requirements": ["neohubapi>=0.8"],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "zeroconf": [
     {"type":"_hap._tcp.local.", "name": "Heatmiser neoHub*"}
   ]

--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from neohubapi.neohub import NeoHub, NeoStat
-from .const import DOMAIN, HUB, COORDINATOR
+from .const import DOMAIN, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -11,8 +11,6 @@ https://github.com/RJ/heatmiser-neohub.py/blob/master/neohub_docs/NeoHub%20comma
 """
 
 import logging
-from datetime import timedelta
-import async_timeout
  
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.update_coordinator import (
@@ -21,50 +19,24 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from neohubapi.neohub import NeoHub, NeoStat
-from .const import DOMAIN, HUB
+from .const import DOMAIN, HUB, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
 
 
 NEO_STAT = 1
 NEO_PLUG = 2
-
+TIMECLOCKS = 'timeclocks'
 
 async def async_setup_entry(hass, entry, async_add_entities):
-
-    hub = hass.data[DOMAIN][HUB]
-
-    async def async_update_data():
-        """Fetch data from the Hub all at once and make it available for
-           all thermostats.
-        """
-        _LOGGER.info(f"Executing update_data()")
-        
-        async with async_timeout.timeout(30):
-            _, devices_data = await hub.get_live_data()
-            system_data = await hub.get_system()
-            #_LOGGER.debug(f"system_data: {system_data}")
-            
-            timers = {timer.name : timer for timer in devices_data['timeclocks']}
-            _LOGGER.debug(f"timers: {timers}")
-            
-            return (timers, system_data)
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        # Name of the data. For logging purposes.
-        name="timer",
-        update_method=async_update_data,
-        # Polling interval. Will only be polled if there are subscribers.
-        update_interval=timedelta(seconds=30),
-    )
     
-    await coordinator.async_config_entry_first_refresh()
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
-    (timers, system_data) = coordinator.data
-
+    (devices_data, system_data) = coordinator.data
+    timers = {device.name : device for device in devices_data[TIMECLOCKS]}
+    
     entities = [NeoTimerEntity(timer, NEO_STAT, coordinator) for timer in timers.values()]
+    
     _LOGGER.info(f"Adding Timers: {entities}")
     async_add_entities(entities, True)
     
@@ -84,7 +56,8 @@ class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
     def data(self):
         """Helper to get the data for the current thermostat. """
         (devices, _) = self._coordinator.data
-        return devices[self.name]
+        timers = {device.name : device for device in devices[TIMECLOCKS]}
+        return timers[self.name]
         
     @property
     def should_poll(self):


### PR DESCRIPTION
Changes to extend PR https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/88 to further improve performance.  Moved update_data() from individual entity files to init.py so that hub.get_live_data() is only called once.