### PR TITLE
Rework target_temperature_step to use neohub api

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.const import CONF_HOST,CONF_PORT
 
 from neohubapi.neohub import NeoHub
-from .const import DOMAIN, COORDINATOR
+from .const import DOMAIN, HUB, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +54,7 @@ async def async_setup_entry(hass, entry):
         update_interval=timedelta(seconds=30)
     )
 
+    hass.data[DOMAIN][HUB] = hub
     hass.data[DOMAIN][COORDINATOR] = coordinator
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -3,6 +3,7 @@
 """Constants used by multiple Heatmiser Neo modules."""
 DOMAIN = "heatmiserneo"
 
+HUB = "Hub"
 COORDINATOR = "Coordinator"
 
 DEFAULT_HOST = "Neo-Hub"

--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from neohubapi.neohub import NeoHub, NeoStat
-from .const import DOMAIN, COORDINATOR
+from .const import DOMAIN, HUB, COORDINATOR
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,25 +30,26 @@ TIMECLOCKS = 'timeclocks'
 
 async def async_setup_entry(hass, entry, async_add_entities):
     
+    hub: NeoHub = hass.data[DOMAIN][HUB]
     coordinator: DataUpdateCoordinator = hass.data[DOMAIN][COORDINATOR]
 
     (devices_data, system_data) = coordinator.data
     timers = {device.name : device for device in devices_data[TIMECLOCKS]}
     
-    entities = [NeoTimerEntity(timer, NEO_STAT, coordinator) for timer in timers.values()]
+    entities = [NeoTimerEntity(timer, coordinator, NEO_STAT) for timer in timers.values()]
     
     _LOGGER.info(f"Adding Timers: {entities}")
     async_add_entities(entities, True)
     
 class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
     """ Represents a Heatmiser neoStat thermostat. """
-    def __init__(self, timer: NeoStat, type, coordinator: DataUpdateCoordinator):
+    def __init__(self, timer: NeoStat, coordinator: DataUpdateCoordinator, type):
         super().__init__(coordinator)
         _LOGGER.debug(f"Creating {timer}")
         
         self._timer = timer
-        self._type = type
         self._coordinator = coordinator
+        self._type = type
         self._state = timer.timer_on
         self._holdfor = 30
 


### PR DESCRIPTION
Use neohub api to determine the target_temperature_step, based on the firmware version (instead of replicating the logic in the heatmiser integration).