### PR TITLE
Update README.md - you want the folder in custom_componetns, not the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Install and configure SSH server from the "Add-on store". Once you have shell ru
 cd /config/
 mkdir custom_components
 cd /config/custom_components
-git clone https://github.com/MindrustUK/Heatmiser-for-home-assistant
-mv Heatmiser-for-home-assistant heatmiserneo
+git clone https://github.com/MindrustUK/Heatmiser-for-home-assistant /tmp/heatmiserneo
+mv /tmp/heatmiserneo/custom-components/heatmiserneo .
 ```
 
 For Windows 10 Manual installation:


### PR DESCRIPTION
…whole repo

You want the folder in `custom_components`, not the whole repo.

With the whole repo, you'll get this error:
> ERROR (MainThread) [homeassistant.config] Platform error: climate - Integration 'heatmiserneo' not found.

Grabbing the folder in `custom_components`, it'll work :)