### PR TITLE
Update README.md - NeoStat WiFi not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Heatmiser Neo-Hub / Neostat / Neostat-e support for home-assistant.io
 This is a work in progress for adding Heatmiser Neo-hub support to Home Assistant (https://home-assistant.io/), I maintain this as a weekend project only so don't expect fast updates but feel free to raise issues as needed.
 
 # Known issues - Read me first!
-For some reason Heatmiser have labeled the API used by this intergration as "Legacy API". Please note if your intergration stops working, or doesn't work on initial installation, please check the phone app and enable "Legacy API" support.
+For some reason Heatmiser have labeled the API used by this intergration as "Legacy API". Please note if your integration stops working, or doesn't work on initial installation, please check the phone app and enable "Legacy API" support.
+
+Please also note that the NeoStat WiFi does not have an API, and so cannot be used with this (or any) NeoHub-based integration.
 
 # Installation:
 


### PR DESCRIPTION
Submitting a request here to update the README so that it is clear that the new [NeoStat WiFi](https://www.heatmiser.com/en/neostat-wifi/) devices are 
a) not supported by this integration and 
b) don't have any API at all as of June 2023 (i.e. not the legacy API on port 4242 or the new web socket API on port 4243), as confirmed by a Heatmiser R&D employee on their developer forum https://dev.heatmiser.com/t/unable-to-find-api-access-in-settings/751 (account required to access).
As their developer forum don't appear in results from any search engines, I wanted to save others from making the same false assumption I did that the NeoStat WiFi would have an API of some description that could be integrated into HomeAssistant!
As it stands, NeoStat WiFi devices should still be possible to add into HomeAssistant via the HomeKit integration (have yet to confirm this myself), but obviously with significantly limited functionality vs an official integration such as this one, as discussed here: https://community.home-assistant.io/t/heatmiser-neo-hub-support-ugly-and-work-in-progress/48/84