### PR TITLE
Set standby (set_frost) mode for 'timeclocks' that are neostats

### DIFF
--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -121,8 +121,8 @@ class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
 
     async def async_switch_on(self, value: bool):
         if self._type == NEO_STAT:
-            response = await self._timer.set_frost(value)
-            _LOGGER.info(f"{self.name} : Called set_frost with: {value} (response: {response})")
+            response = await self._timer.set_frost(not value)
+            _LOGGER.info(f"{self.name} : Called set_frost with: {not value} (response: {response})")
             self.data.timer_on = value
             self.async_write_ha_state()
             

--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -121,8 +121,8 @@ class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
 
     async def async_switch_on(self, value: bool):
         if self._type == NEO_STAT:
-            response = await self._timer.set_timer_hold(value, self._holdfor if value else 0)
-            _LOGGER.info(f"{self.name} : Called set_timer_hold with: {value} (response: {response})")
+            response = await self._timer.set_frost(value)
+            _LOGGER.info(f"{self.name} : Called set_frost with: {value} (response: {response})")
             self.data.timer_on = value
             self.async_write_ha_state()
             


### PR DESCRIPTION
The neostat-hw (hot water) controls are currently exposed as a switch as they come through the api as neostat timerclocks. 
When you toggle the switch, at the moment it sets a hold timer for a minute rather than turning the hot water on/off properly. 

This changes it to call the set_frost mode (which is Standby in the app), which means the switch actually stays off once toggled.