### PR TITLE
Revert "Set standby (set_frost) mode for 'timeclocks' that are neostats"

### DIFF
--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -121,8 +121,8 @@ class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
 
     async def async_switch_on(self, value: bool):
         if self._type == NEO_STAT:
-            response = await self._timer.set_frost(not value)
-            _LOGGER.info(f"{self.name} : Called set_frost with: {not value} (response: {response})")
+            response = await self._timer.set_timer_hold(value, self._holdfor if value else 0)
+            _LOGGER.info(f"{self.name} : Called set_timer_hold with: {value} (response: {response})")
             self.data.timer_on = value
             self.async_write_ha_state()
             


### PR DESCRIPTION
Reverts MindrustUK/Heatmiser-for-home-assistant#146

Looks like this has created an undesired logic change and should probably be reworked. Have reverted until I get a chance to investigate further following the next release.