### PR TITLE
Cache NeoStat state for existing entities

### DIFF
--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -127,6 +127,7 @@ class NeoStatEntity(CoordinatorEntity, ClimateEntity):
         self._unit_of_measurement = unit_of_measurement
         self._target_temperature_step = temperature_step
         self._hvac_modes = []
+        self._available = True
         if hasattr(neostat, "standby"):
             self._hvac_modes.append(HVAC_MODE_OFF)
         for mode in neostat.available_modes:
@@ -137,7 +138,12 @@ class NeoStatEntity(CoordinatorEntity, ClimateEntity):
         """Helper to get the data for the current thermostat."""
         (devices, _) = self._coordinator.data
         thermostats = {device.name: device for device in devices[THERMOSTATS]}
-        return thermostats[self.name]
+        if self.name in thermostats:
+            self._neostat = thermostats[self.name]
+            self._available = True
+        else:
+            self._available = False
+        return self._neostat
 
     @property
     def supported_features(self):
@@ -171,6 +177,11 @@ class NeoStatEntity(CoordinatorEntity, ClimateEntity):
     def unique_id(self):
         """Return a unique ID."""
         return self._neostat.name
+
+    @property
+    def available(self):
+        """Return true if the entity is available."""
+        return self._available
 
     @property
     def temperature_unit(self):

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -135,13 +135,19 @@ class NeoStatOfflineBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
         self._neostat = neostat
         self._coordinator = coordinator
+        self._available = True
 
     @property
     def data(self):
         """Helper to get the data for the current thermostat."""
         (devices, _) = self._coordinator.data
         thermostats = {device.name: device for device in devices[THERMOSTATS]}
-        return thermostats[self._neostat.name]
+        if self.name in thermostats:
+            self._neostat = thermostats[self.name]
+            self._available = True
+        else:
+            self._available = False
+        return self._neostat
 
     @property
     def name(self):
@@ -156,7 +162,7 @@ class NeoStatOfflineBinarySensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def available(self):
         """Return true if the entity is available."""
-        return True
+        return self._available
 
     @property
     def unique_id(self):

--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -52,13 +52,19 @@ class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
         self._type = type
         self._state = timer.timer_on
         self._holdfor = 30
+        self._available = True
 
     @property
     def data(self):
         """Helper to get the data for the current thermostat. """
         (devices, _) = self._coordinator.data
         timers = {device.name : device for device in devices[TIMECLOCKS]}
-        return timers[self.name]
+        if self.name in timers:
+            self._timer = timers[self.name]
+            self._available = True
+        else:
+            self._available = False
+        return self._timer
         
     @property
     def should_poll(self):
@@ -88,7 +94,7 @@ class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
     @property
     def available(self):
         """Return true if the entity is available."""
-        return True
+        return self._available
       
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
If NeoHub stops reporting data for a device, keep using its previous state and mark it as unavailable.

Fixes #183