### PR TITLE
Timer hold 182

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ You can apply a hold using the `heatmiserneo.hold_on` service.  This can be used
 If there is an existing hold on any device targeted by the service call, it is replaced by the new hold.
 ## Release Hold
 You can release any existing hold on a NeoStat specified by entity, device or area.  There are no other parameters.
+## Timer Hold
+You can apply a hold to a timer entity using the `heatmiserneo.timer_hold_on` service.  This can be used to target an entity, device or area operating in timer mode and also accepts the following parameters:
+- `hold_duration` - how long to hold the specified temperature.  This is given in Home Assistant duration format (hh:mm e.g. `hold_duration: 01:30`)
+
+If there is an existing hold on any device targeted by the service call, it is replaced by the new hold.
 
 ## Related Attributes
 NeoStat climate entities reads the following attributes that are relevant to the Hold functionality:

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -16,6 +16,8 @@ CONF_HVAC_MODES = "hvac_modes"
 
 SERVICE_HOLD_ON = "hold_on"
 SERVICE_HOLD_OFF = "hold_off"
+SERVICE_TIMER_HOLD_ON = "timer_hold_on"
+SERVICE_TIMER_HOLD_OFF = "timer_hold_off"
 ATTR_HOLD_DURATION = "hold_duration"
 ATTR_HOLD_TEMPERATURE = "hold_temperature"
 

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -17,7 +17,6 @@ CONF_HVAC_MODES = "hvac_modes"
 SERVICE_HOLD_ON = "hold_on"
 SERVICE_HOLD_OFF = "hold_off"
 SERVICE_TIMER_HOLD_ON = "timer_hold_on"
-SERVICE_TIMER_HOLD_OFF = "timer_hold_off"
 ATTR_HOLD_DURATION = "hold_duration"
 ATTR_HOLD_TEMPERATURE = "hold_temperature"
 

--- a/custom_components/heatmiserneo/services.yaml
+++ b/custom_components/heatmiserneo/services.yaml
@@ -31,3 +31,20 @@ hold_off:
     entity:
       integration: heatmiserneo
       domain: climate
+timer_hold_on:
+  name: Timer Hold On
+  description: Instruct the NeoStat in TimeClock mode or NeoPlug to 'hold' for a specified period of time.
+  target:
+    entity:
+      integration: heatmiserneo
+      domain: switch
+      supported_features:
+        - siren.SirenEntityFeature.DURATION
+  fields:
+    hold_duration:
+      name: Hold Duration
+      description: Set the duration for the hold (hh:mm:ss).
+      default: '01:00:00'
+      example: '01:00:00'
+      selector:
+        duration:

--- a/custom_components/heatmiserneo/services.yaml
+++ b/custom_components/heatmiserneo/services.yaml
@@ -38,8 +38,6 @@ timer_hold_on:
     entity:
       integration: heatmiserneo
       domain: switch
-      supported_features:
-        - siren.SirenEntityFeature.DURATION
   fields:
     hold_duration:
       name: Hold Duration


### PR DESCRIPTION
Hi @MindrustUK, this is an attempt to bring back the timer switch functionality that was lost on the upgrade to v1.5 (#182) . I have added the switch back in which reflects the state of the `timer_on` state. Turning on the switch from the UI sets a hold of 30 minutes and turning off the switch removes the hold. Additionally, I have added a `timer_hold_on` service that can allow users to set a hold with a custom duration.

I think this change makes the 'HeatmiserNeoTimerOutputActiveSensor' redundant but I haven't removed it in this PR. 

![image](https://github.com/user-attachments/assets/7587516e-05f7-4dd9-8a1a-24fecb85c533)
![image](https://github.com/user-attachments/assets/a8cb087e-7f00-4522-b57d-da5952cfe119)

You'll notice I added
```
self._attr_supported_features = SirenEntityFeature.DURATION
```
Which borrows the `DURATION` feature from the siren entity. I'm using this to filter the entities in the service call, otherwise all switches from this integration appear in the selector. I believe that while its possible to create custom features, the filtering only works with the ones defined by Home Assistant itself.

Feel free to use it as is, make changes or give me feedback so I can make the changes. 