### PR TITLE
Fix for timer hold service targeting all switch entities on device

### DIFF
--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -7,6 +7,7 @@ homeassistant.components.switch.heatmiserneo
 """
 
 from datetime import time
+from enum import IntFlag
 import logging
 
 import voluptuous as vol
@@ -76,7 +77,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
             vol.Required(ATTR_HOLD_DURATION, default=1): cv.positive_time_period,
         },
         "async_turn_on",
+        [HeatmiseerNeoSwitchEntityFeature.HOLD],
     )
+
+
+class HeatmiseerNeoSwitchEntityFeature(IntFlag):
+    """Supported features of the heatmiser neo switches entity."""
+
+    HOLD = 1
 
 
 class HeatmiserNeoPlugPowerSwitch(CoordinatorEntity, SwitchEntity):
@@ -410,6 +418,8 @@ class HeatmiserTimerDeviceStandbySwitch(CoordinatorEntity, SwitchEntity):
 
 class NeoTimerEntity(CoordinatorEntity, SwitchEntity):
     """Represents a Heatmiser neoStat thermostat acting in TimeClock mode."""
+
+    _attr_supported_features = HeatmiseerNeoSwitchEntityFeature.HOLD
 
     def __init__(
         self, neostat: NeoStat, coordinator: DataUpdateCoordinator, hub: NeoHub


### PR DESCRIPTION
The original implementation of the timer_hold_on service would update all switches on the device (eg it would also turn on Standby). I have added a custom entity feature and applied it to the relevant switch so now only that switch is targeted when using the service on the device. 

Note that other switches still appear on the entity dropdown when setting up the service call in the UI, but you get a warning afterwards saying its not supported:

![image](https://github.com/user-attachments/assets/bfcd5398-ed22-4439-92e4-3d64491c7d5f)

![image](https://github.com/user-attachments/assets/a77449d3-208c-4e5c-aa64-0dcfa50a6c52)
