### PR TITLE
Improved user experience of Away mode

### DIFF
--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -130,7 +130,7 @@ async def async_setup_entry(
 class HeatmiserNeoClimateEntityDescription(
     HeatmiserNeoEntityDescription, ClimateEntityDescription
 ):
-    """Describes a button entity."""
+    """Describes a Climate entity."""
 
 
 CLIMATE: tuple[HeatmiserNeoClimateEntityDescription, ...] = (
@@ -484,15 +484,10 @@ class NeoStatEntity(HeatmiserNeoEntity, ClimateEntity):
         """Set preset mode."""
         device = self.data
         if preset_mode == PRESET_AWAY:
-            await self._hub.set_away(True)
-            device.away = True
-        elif device.away:
-            await self._hub.set_away(False)
-            device.away = False
+            await self.async_set_away_mode()
+        elif device.away or device.holiday:
+            await self.async_cancel_away_or_holiday()
 
-        if device.holiday:
-            await self._hub.cancel_holiday()
-            device.holiday = False
         hold_temp = float(device.target_temperature)
         hold_duration = 0
         hold_on = False
@@ -509,4 +504,3 @@ class NeoStatEntity(HeatmiserNeoEntity, ClimateEntity):
             device.hold_time = timedelta(minutes=hold_duration)
 
         self.coordinator.async_update_listeners()
-        await self.coordinator.async_request_refresh()

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -93,6 +93,7 @@ class ModeSelectOption(str, enum.Enum):
     STANDBY = "standby"
     MANUAL_ON = "on"
     MANUAL_OFF = "off"
+    AWAY = "away"
 
 
 HEATMISER_TEMPERATURE_UNIT_HA_UNIT = {

--- a/custom_components/heatmiserneo/coordinator.py
+++ b/custom_components/heatmiserneo/coordinator.py
@@ -2,10 +2,11 @@
 """Coordinator object for the HeatmiserNeo integration."""
 
 import asyncio
+from collections.abc import Callable
 from datetime import timedelta
 import logging
 
-from neohubapi.neohub import NeoHub
+from neohubapi.neohub import NeoHub, NeoStat
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -73,3 +74,12 @@ class HeatmiserNeoCoordinator(DataUpdateCoordinator[NeoHub]):
         return self._device_serial_numbers.get(device_id, {}).get(
             "serial_number", "UNKNOWN"
         )
+
+    def update_in_memory_state(
+        self, action: Callable[[NeoStat], None], filter: Callable[[NeoStat], bool]
+    ) -> None:
+        """Call action on devices matching filter."""
+        devices, _ = self.data
+        for device in devices["neo_devices"]:
+            if filter(device):
+                action(device)

--- a/custom_components/heatmiserneo/coordinator.py
+++ b/custom_components/heatmiserneo/coordinator.py
@@ -80,6 +80,6 @@ class HeatmiserNeoCoordinator(DataUpdateCoordinator[NeoHub]):
     ) -> None:
         """Call action on devices matching filter."""
         devices, _ = self.data
-        for device in devices["neo_devices"]:
+        for device in devices.values():
             if filter(device):
                 action(device)

--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from functools import partial
 import logging
 from typing import Any
 
@@ -15,8 +16,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, HEATMISER_PRODUCT_LIST
+from .const import DOMAIN, HEATMISER_PRODUCT_LIST, HEATMISER_TYPE_IDS_AWAY
 from .coordinator import HeatmiserNeoCoordinator
+from .helpers import cancel_holiday, set_away
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +32,8 @@ class HeatmiserNeoEntityDescription(EntityDescription):
     icon_fn: Callable[[NeoStat], str | None] | None = None
     # extra_attrs: list[str] | None = None
     custom_functions: (
-        dict[str, Callable[[NeoStat, NeoHub, ServiceCall], Awaitable[None]]] | None
+        dict[str, Callable[[type[HeatmiserNeoEntity], ServiceCall], Awaitable[None]]]
+        | None
     ) = None
 
 
@@ -138,9 +141,40 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
             self.data, self._hub, service_call
         )
 
+    async def async_cancel_away_or_holiday(self) -> None:
+        """Cancel away/holiday mode."""
+        if _device_supports_away(self.data):
+            dev = self.data
+            if dev.away:
+                await self._hub.set_away(False)
+                self.coordinator.update_in_memory_state(
+                    partial(set_away, False),
+                    _device_supports_away,
+                )
+            if dev.holiday:
+                await self._hub.cancel_holiday(False)
+                self.coordinator.update_in_memory_state(
+                    cancel_holiday,
+                    _device_supports_away,
+                )
+
+    async def async_set_away_mode(self) -> None:
+        """Set away mode."""
+        if _device_supports_away(self.data):
+            dev = self.data
+            if not (dev.away or dev.holiday):
+                await self._hub.set_away(True)
+                self.coordinator.update_in_memory_state(
+                    partial(set_away, True), _device_supports_away
+                )
+
 
 async def call_custom_action(
     entity: HeatmiserNeoEntity, service_call: ServiceCall
 ) -> None:
     """Call a custom action specified in the entity description."""
     await entity.call_custom_action(service_call)
+
+
+def _device_supports_away(dev: NeoStat) -> bool:
+    return dev.device_type in HEATMISER_TYPE_IDS_AWAY

--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -138,7 +138,7 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
             )
             return
         await self.entity_description.custom_functions.get(service_call.service)(
-            self.data, self._hub, service_call
+            self, service_call
         )
 
     async def async_cancel_away_or_holiday(self) -> None:

--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+"""Constants used by multiple Heatmiser Neo modules."""
+
+from neohubapi.neohub import NeoStat
+
+
+def set_away(state: bool, dev: NeoStat) -> None:
+    """Set away flag on device."""
+    dev.away = state
+    if state:
+        dev.target_temperature = dev._data_.FROST_TEMP
+
+
+def cancel_holiday(dev: NeoStat) -> None:
+    """Cancel holiday on device."""
+    dev.holiday = False

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -46,22 +46,40 @@ class HeatmiserNeoSelectEntityDescription(HeatmiserNeoEntityDescription):
 
     options: list[str]
     value_fn: Callable[[NeoStat], str]
-    set_value_fn: Callable[[str, NeoStat, NeoHub], Awaitable[None]]
+    set_value_fn: Callable[[str, HeatmiserNeoSelectEntity], Awaitable[None]]
 
 
-async def set_timer_auto(dev: NeoStat):
+async def set_timer_auto(entity: HeatmiserNeoSelectEntity):
     """Set device back to auto based on its current state."""
+    dev = entity.data
     if dev.standby:
-        await set_timer_standby(dev, False)
-    else:
-        await set_timer_override(dev, dev.hold_temp == 1, 0)
+        await set_timer_standby(entity, False)
+    if dev.hold_on:
+        await set_timer_override(entity, dev.hold_temp == 1, 0)
+    await entity.async_cancel_away_or_holiday()
+
+
+async def set_timer_away(entity: HeatmiserNeoSelectEntity):
+    """Set device back to auto based on its current state."""
+    dev = entity.data
+    if dev.standby:
+        await set_timer_standby(entity, False)
+    if dev.hold_on:
+        await set_timer_override(entity, dev.hold_temp == 1, 0)
+    await entity.async_set_away_mode()
 
 
 async def set_timer_override(
-    dev: NeoStat, on: bool, duration: int = DEFAULT_TIMER_HOLD_DURATION
+    entity: HeatmiserNeoSelectEntity,
+    on: bool,
+    duration: int = DEFAULT_TIMER_HOLD_DURATION,
 ):
     """Set timer override."""
+    dev = entity.data
     state = duration > 0
+    if state and (dev.away or dev.holiday):
+        # Can't enable hold while away/holiday
+        return
     if state and on and dev.standby:
         await set_timer_standby(dev, False)
     await dev.set_timer_hold(on, duration)
@@ -72,8 +90,9 @@ async def set_timer_override(
     dev.hold_time = timedelta(minutes=duration)
 
 
-async def set_timer_standby(dev: NeoStat, state: bool = True):
+async def set_timer_standby(entity: HeatmiserNeoSelectEntity, state: bool = True):
     """Set standby mode. Disable hold if set."""
+    dev = entity.data
     if state and dev.hold_on:
         await set_timer_override(dev, dev.hold_temp == 1, 0)
     await dev.set_frost(state)
@@ -82,19 +101,29 @@ async def set_timer_standby(dev: NeoStat, state: bool = True):
         dev.timer_on = False
 
 
-async def set_plug_auto(dev: NeoStat, hub: NeoHub):
+async def set_plug_auto(entity: HeatmiserNeoSelectEntity):
     """Set device back to auto based on its current state."""
-    set_plug_override(dev, hub, dev.hold_temp == 1, 0)
+    dev = entity.data
+    set_plug_override(entity, dev.hold_temp == 1, 0)
+    await entity.async_cancel_away_or_holiday()
+
+
+async def set_plug_away(entity: HeatmiserNeoSelectEntity):
+    """Set device back to auto based on its current state."""
+    dev = entity.data
+    set_plug_override(entity, dev.hold_temp == 1, 0)
+    await entity.async_set_away_mode()
 
 
 async def set_plug_override(
-    dev: NeoStat,
-    hub: NeoHub,
+    entity: HeatmiserNeoSelectEntity,
     on: bool,
     duration: int = DEFAULT_PLUG_HOLD_DURATION,
     turn_off_manual: bool = True,
 ):
     """Set timer override. Disable manual if set."""
+    dev = entity.data
+    hub = entity.coordinator.hub
     if turn_off_manual and not dev.manual_off:
         await hub.set_manual(False, [dev])
         dev.manual_off = True
@@ -109,9 +138,11 @@ async def set_plug_override(
         dev.hold_time = timedelta(minutes=duration)
 
 
-async def set_plug_manual(dev: NeoStat, hub: NeoHub, on: bool):
+async def set_plug_manual(entity: HeatmiserNeoSelectEntity, on: bool):
     """Set standby mode. Disable hold if set."""
-    set_plug_override(dev, hub, dev.hold_temp == 1, 0, False)
+    dev = entity.data
+    hub = entity.coordinator.hub
+    set_plug_override(entity, dev.hold_temp == 1, 0, False)
     if dev.manual_off:
         await hub.set_manual(True, [dev])
         dev.manual_off = False
@@ -121,6 +152,13 @@ async def set_plug_manual(dev: NeoStat, hub: NeoHub, on: bool):
 
 
 def _timer_mode(device: NeoStat) -> ModeSelectOption:
+    """Decode the timer mode."""
+    # If Hub Away, Device can be on standby
+    # Else if device on Standby, Hold can be enabled
+    if device.away or device.holiday:
+        if device.standby:
+            return ModeSelectOption.STANDBY
+        return ModeSelectOption.AWAY
     if device.hold_on:
         if device.hold_temp == 1:
             return ModeSelectOption.OVERRIDE_ON
@@ -149,6 +187,8 @@ def _plug_mode(device: NeoStat) -> ModeSelectOption:
         if device.hold_temp == 1:
             return ModeSelectOption.OVERRIDE_ON
         return ModeSelectOption.OVERRIDE_OFF
+    # if device.away or device.holiday:
+    #     return ModeSelectOption.AWAY
     return ModeSelectOption.AUTO
 
 
@@ -163,38 +203,39 @@ def _plug_icon(device: NeoStat) -> str | None:
         return "mdi:timer-stop-outline"
     return "mdi:timer" if device.timer_on else "mdi:timer-outline"
 
-
-async def async_timer_hold(device: NeoStat, hub: NeoHub, service_call: ServiceCall):
+async def async_timer_hold(entity: HeatmiserNeoSelectEntity, service_call: ServiceCall):
     """Set override with custom duration."""
     duration = service_call.data[ATTR_HOLD_DURATION]
     state = service_call.data[ATTR_HOLD_STATE]
     hold_minutes = int(duration.total_seconds() / 60)
     hold_minutes = min(hold_minutes, 60 * 99)
-    await set_timer_override(device, state, hold_minutes)
+    await set_timer_override(entity, state, hold_minutes)
 
 
-async def async_plug_hold(device: NeoStat, hub: NeoHub, service_call: ServiceCall):
+async def async_plug_hold(entity: HeatmiserNeoSelectEntity, service_call: ServiceCall):
     """Set override with custom duration."""
     duration = service_call.data[ATTR_HOLD_DURATION]
     state = service_call.data[ATTR_HOLD_STATE]
     hold_minutes = int(duration.total_seconds() / 60)
     hold_minutes = min(hold_minutes, 60 * 99)
-    await set_plug_override(device, hub, state, hold_minutes)
+    await set_plug_override(entity, state, hold_minutes)
 
 
 TIMER_SET_MODE = {
-    ModeSelectOption.AUTO: lambda dev, _: set_timer_auto(dev),
-    ModeSelectOption.OVERRIDE_ON: lambda dev, _: set_timer_override(dev, True),
-    ModeSelectOption.OVERRIDE_OFF: lambda dev, _: set_timer_override(dev, False),
-    ModeSelectOption.STANDBY: lambda dev, _: set_timer_standby(dev),
+    ModeSelectOption.AUTO: set_timer_auto,
+    ModeSelectOption.OVERRIDE_ON: lambda entity: set_timer_override(entity, True),
+    ModeSelectOption.OVERRIDE_OFF: lambda entity: set_timer_override(entity, False),
+    ModeSelectOption.STANDBY: set_timer_standby,
+    ModeSelectOption.AWAY: set_timer_away,
 }
 
 PLUG_SET_MODE = {
     ModeSelectOption.AUTO: set_plug_auto,
-    ModeSelectOption.OVERRIDE_ON: lambda dev, hub: set_plug_override(dev, hub, True),
-    ModeSelectOption.OVERRIDE_OFF: lambda dev, hub: set_plug_override(dev, hub, False),
-    ModeSelectOption.MANUAL_ON: lambda dev, hub: set_plug_manual(dev, hub, True),
-    ModeSelectOption.MANUAL_OFF: lambda dev, hub: set_plug_manual(dev, hub, False),
+    ModeSelectOption.OVERRIDE_ON: lambda entity: set_plug_override(entity, True),
+    ModeSelectOption.OVERRIDE_OFF: lambda entity: set_plug_override(entity, False),
+    ModeSelectOption.MANUAL_ON: lambda entity: set_plug_manual(entity, True),
+    ModeSelectOption.MANUAL_OFF: lambda entity: set_plug_manual(entity, False),
+    # ModeSelectOption.AWAY: set_plug_away,
 }
 
 SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
@@ -208,8 +249,8 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
             and device.time_clock_mode
         ),
         value_fn=lambda dev: _timer_mode(dev).value,
-        set_value_fn=lambda mode, dev, hub: TIMER_SET_MODE.get(ModeSelectOption(mode))(
-            dev, hub
+        set_value_fn=lambda mode, entity: TIMER_SET_MODE.get(ModeSelectOption(mode))(
+            entity
         ),
         icon_fn=_timer_icon,
         translation_key="timer_mode",
@@ -221,8 +262,8 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
         options=[c.value.lower() for c in PLUG_SET_MODE],
         setup_filter_fn=lambda device, _: device.device_type in HEATMISER_TYPE_IDS_PLUG,
         value_fn=lambda dev: _plug_mode(dev).value,
-        set_value_fn=lambda mode, dev, hub: PLUG_SET_MODE.get(ModeSelectOption(mode))(
-            dev, hub
+        set_value_fn=lambda mode, entity: PLUG_SET_MODE.get(ModeSelectOption(mode))(
+            entity
         ),
         icon_fn=_plug_icon,
         translation_key="plug_mode",
@@ -288,14 +329,9 @@ class HeatmiserNeoSelectEntity(HeatmiserNeoEntity, SelectEntity):
         )
         self._attr_current_option = entity_description.value_fn(neostat)
 
-    @property
-    def current_option(self) -> str | None:
-        """Return the selected entity option to represent the entity state."""
-        return self.entity_description.value_fn(self.data)
-
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self.entity_description.set_value_fn(option, self.data, self._hub)
+        await self.entity_description.set_value_fn(option, self)
         self.coordinator.async_update_listeners()
 
     @callback
@@ -303,25 +339,3 @@ class HeatmiserNeoSelectEntity(HeatmiserNeoEntity, SelectEntity):
         """Handle updated data from the coordinator."""
         self._attr_current_option = self.entity_description.value_fn(self.data)
         super()._handle_coordinator_update()
-
-
-def _timer_mode(device: NeoStat) -> str:
-    if device.hold_on:
-        if device.hold_temp == 1:
-            return ModeSelectOption.OVERRIDE_ON
-        return ModeSelectOption.OVERRIDE_OFF
-    if device.standby:
-        return ModeSelectOption.STANDBY
-    return ModeSelectOption.AUTO
-
-
-def _plug_mode(device: NeoStat) -> str:
-    if not device.manual_off:
-        if device.timer_on:
-            return ModeSelectOption.MANUAL_ON
-        return ModeSelectOption.MANUAL_OFF
-    if device.hold_on:
-        if device.hold_temp == 1:
-            return ModeSelectOption.OVERRIDE_ON
-        return ModeSelectOption.OVERRIDE_OFF
-    return ModeSelectOption.AUTO

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -107,11 +107,11 @@ async def set_plug_auto(entity: HeatmiserNeoSelectEntity):
     await entity.async_cancel_away_or_holiday()
 
 
-async def set_plug_away(entity: HeatmiserNeoSelectEntity):
-    """Set device back to auto based on its current state."""
-    dev = entity.data
-    set_plug_override(entity, dev.hold_temp == 1, 0)
-    await entity.async_set_away_mode()
+# async def set_plug_away(entity: HeatmiserNeoSelectEntity):
+#     """Set device back to auto based on its current state."""
+#     dev = entity.data
+#     set_plug_override(entity, dev.hold_temp == 1, 0)
+#     await entity.async_set_away_mode()
 
 
 async def set_plug_override(
@@ -168,6 +168,10 @@ def _timer_mode(device: NeoStat) -> ModeSelectOption:
 
 
 def _timer_icon(device: NeoStat) -> str | None:
+    if device.away or device.holiday:
+        if device.standby:
+            return "mdi:timer-off-outline"
+        return "mdi:account-arrow-right"
     if device.hold_on:
         if device.hold_temp == 1:
             return "mdi:timer-stop"
@@ -182,8 +186,8 @@ def _plug_mode(device: NeoStat) -> ModeSelectOption:
         if device.timer_on:
             return ModeSelectOption.MANUAL_ON
         return ModeSelectOption.MANUAL_OFF
-    if device.away or device.holiday:
-        return ModeSelectOption.AWAY
+    # if device.away or device.holiday:
+    #     return ModeSelectOption.AWAY
     if device.hold_on:
         if device.hold_temp == 1:
             return ModeSelectOption.OVERRIDE_ON
@@ -201,6 +205,7 @@ def _plug_icon(device: NeoStat) -> str | None:
             return "mdi:timer-stop"
         return "mdi:timer-stop-outline"
     return "mdi:timer" if device.timer_on else "mdi:timer-outline"
+
 
 async def async_timer_hold(entity: HeatmiserNeoSelectEntity, service_call: ServiceCall):
     """Set override with custom duration."""
@@ -236,7 +241,7 @@ PLUG_SET_MODE = {
     ModeSelectOption.OVERRIDE_OFF: lambda entity: set_plug_override(entity, False),
     ModeSelectOption.MANUAL_ON: lambda entity: set_plug_manual(entity, True),
     ModeSelectOption.MANUAL_OFF: lambda entity: set_plug_manual(entity, False),
-    ModeSelectOption.AWAY: set_plug_away,
+    # ModeSelectOption.AWAY: set_plug_away,
 }
 
 SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -45,8 +45,7 @@
           "on": "On",
           "off": "Off",
           "override_on": "Override On",
-          "override_off": "Override Off",
-          "away": "Away"
+          "override_off": "Override Off"
         }
       }
     }

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -35,7 +35,8 @@
           "auto": "Auto",
           "standby": "Standby",
           "override_on": "Override On",
-          "override_off": "Override Off"
+          "override_off": "Override Off",
+          "away": "Away"
         }
       },
       "plug_mode": {
@@ -44,7 +45,8 @@
           "on": "On",
           "off": "Off",
           "override_on": "Override On",
-          "override_off": "Override Off"
+          "override_off": "Override Off",
+          "away": "Away"
         }
       }
     }

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -49,8 +49,7 @@
           "on": "On",
           "off": "Off",
           "override_on": "Override On",
-          "override_off": "Override Off",
-          "away": "Away"
+          "override_off": "Override Off"
         }
       }
     }

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -39,7 +39,8 @@
           "auto": "Auto",
           "standby": "Standby",
           "override_on": "Override On",
-          "override_off": "Override Off"
+          "override_off": "Override Off",
+          "away": "Away"
         }
       },
       "plug_mode": {
@@ -48,7 +49,8 @@
           "on": "On",
           "off": "Off",
           "override_on": "Override On",
-          "override_off": "Override Off"
+          "override_off": "Override Off",
+          "away": "Away"
         }
       }
     }


### PR DESCRIPTION
This PR addresses #206 I haven't made changes for the plugs because I'm not sure how exactly they are supposed to behave. For timers, its like this:

- If the hub is away/holiday, then you can set the timer to standby, but not to override

Plugs don't have standby, instead they have a manual mode where they can be set to on or off. @MindrustUK would you be able to check on the heatmiser app what you are allowed to do on a plug when the hub is away/holiday? Are you still able to switch it on manually? Then I can complete the changes to include the plug as well.

There is a small bug if you try to select Override On/Override Off on a timer if the state is away/holiday. It is not meant to do anything and it doesn't, but the dropdown selector stays in the newly selected state. The state hasn't actually changed and refreshing the screen sets it to the expected value (eg away), but even an update from hub isn't enough to change back on its own. Ideally it would switch back on its own immediately

