### PR TITLE
Fix for Standby mode on timers

### DIFF
--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -62,6 +62,8 @@ async def set_timer_override(
 ):
     """Set timer override."""
     state = duration > 0
+    if state and on and dev.standby:
+        await set_timer_standby(dev, False)
     await dev.set_timer_hold(on, duration)
     dev.hold_on = state
     if state:
@@ -72,7 +74,7 @@ async def set_timer_override(
 
 async def set_timer_standby(dev: NeoStat, state: bool = True):
     """Set standby mode. Disable hold if set."""
-    if dev.hold_on:
+    if state and dev.hold_on:
         await set_timer_override(dev, dev.hold_temp == 1, 0)
     await dev.set_frost(state)
     dev.standby = state


### PR DESCRIPTION
@MindrustUK this is a proposed fix for the standby behaviour of timers we were discussing on #182.

I did some more testing on my NeoStat V2, and while I can put the switch the device to Override On from Standby via the iOS app, it is not possible from the device itself (eg using the touch buttons). 

So this PR adds logic to remove standby if you switch to override on. Try it out on your NeoStat v1 to see if it behaves correctly.