### PR TITLE
Hold remaining sensor device class

### DIFF
--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -4,7 +4,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import timedelta
 import logging
 from typing import Any
 
@@ -23,7 +22,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -91,8 +90,10 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
     HeatmiserNeoSensorEntityDescription(
         key="heatmiser_neo_hold_time_sensor",
         name="Hold Time Remaining",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda device: (
-            device.hold_time if device.hold_on else timedelta(seconds=0)
+            int(device.hold_time.total_seconds() / 60) if device.hold_on else 0
         ),
         setup_filter_fn=lambda device, _: (
             device.device_type in HEATMISER_TYPE_IDS_HOLD


### PR DESCRIPTION
The hold time remaining sensor should use a `SensorDeviceClass.DURATION`. Previously:

![image](https://github.com/user-attachments/assets/a162af2f-f4c2-47a9-9544-bff6f4b5a7e2)

Now with the device class set:

![image](https://github.com/user-attachments/assets/e84ca37c-8bb7-4469-981b-7c25db6fdafd)

Sadly the display still shows with seconds, but that's down to HA:

![image](https://github.com/user-attachments/assets/2217228f-8407-4a3e-8841-e531a71dc7ac)

On the plus side it gives it a nice default icon!

There is a [Feature Request](https://community.home-assistant.io/t/improve-display-of-duration-sensor/696341) open on the HA forums, so maybe one day it will be improved.