### PR TITLE
Handle devices which are no longer reported by the hub

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
@@ -21,6 +21,13 @@ from .coordinator import HeatmiserNeoCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.CLIMATE,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
 
 type HeatmiserNeoConfigEntry = ConfigEntry[HeatmiserNeoData]
 
@@ -86,15 +93,20 @@ async def async_setup_entry(
     entry.runtime_data = HeatmiserNeoData(hub, coordinator)
 
     await coordinator.async_config_entry_first_refresh()
-    await hass.config_entries.async_forward_entry_setups(
-        entry, ["binary_sensor", "button", "climate", "select", "sensor"]
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
+async def async_unload_entry(
+    hass: HomeAssistant, entry: HeatmiserNeoConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
 async def options_update_listener(
-    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+    hass: HomeAssistant, config_entry: HeatmiserNeoConfigEntry
 ):
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)

--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -43,9 +43,7 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up sensor entities")
         return
 
-    devices_data, system_data = coordinator.data
-
-    neo_devices = {device.name: device for device in devices_data["neo_devices"]}
+    neo_devices, system_data = coordinator.data
 
     _LOGGER.info("Adding Neo Binary Sensors")
 

--- a/custom_components/heatmiserneo/button.py
+++ b/custom_components/heatmiserneo/button.py
@@ -34,9 +34,8 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up button entities")
         return
 
-    devices_data, system_data = coordinator.data
+    neo_devices, system_data = coordinator.data
 
-    neo_devices = {device.name: device for device in devices_data["neo_devices"]}
     _LOGGER.info("Adding Neo Device Buttons")
 
     async_add_entities(

--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -71,8 +71,7 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up climate entities")
         return
 
-    devices_data, system_data = coordinator.data
-    thermostats = {device.name: device for device in devices_data["neo_devices"]}
+    thermostats, system_data = coordinator.data
 
     hvac_config = entry.options.get(CONF_HVAC_MODES, {})
 

--- a/custom_components/heatmiserneo/coordinator.py
+++ b/custom_components/heatmiserneo/coordinator.py
@@ -64,7 +64,8 @@ class HeatmiserNeoCoordinator(DataUpdateCoordinator[NeoHub]):
                 if getattr(device, "serial_number", None) is None:
                     setattr(device, "serial_number", serial_number)
 
-            return devices_data, system_data
+            devices = {device.name: device for device in devices_data["neo_devices"]}
+            return devices, system_data
 
     def _get_device_sn(self, device_id: int) -> str:
         """Get a device serial number by its device id."""

--- a/custom_components/heatmiserneo/diagnostics.py
+++ b/custom_components/heatmiserneo/diagnostics.py
@@ -28,7 +28,7 @@ async def async_get_config_entry_diagnostics(
     hub = entry.runtime_data.hub
     coordinator = entry.runtime_data.coordinator
 
-    devices_data, system_data = coordinator.data
+    neo_devices, system_data = coordinator.data
     engineers_data = await hub.get_engineers()
     raw_live_data = await hub.get_live_data()
     raw_live_data = vars(raw_live_data)
@@ -37,15 +37,14 @@ async def async_get_config_entry_diagnostics(
         for dev in raw_live_data.get("devices", [])
     ]
     devices = await hub.get_devices()
-    devices_sns = {device.serial_number for device in devices_data["neo_devices"]}
+    devices_sns = {device.serial_number for device in neo_devices.values()}
     devices_sns = {n: "REDACTED-SN-" + str(i) for i, n in enumerate(devices_sns)}
-    zones = {device._data_.ZONE_NAME for device in devices_data["neo_devices"]}
+    zones = {device._data_.ZONE_NAME for device in neo_devices.values()}
     device_list = {z: await retrieve_zone_device_list(z, hub) for z in zones}
     return {
         "config_entry": async_redact_data(entry.as_dict(), TO_REDACT_CONFIG),
         "devices_data": [
-            convert_to_dict(device, devices_sns)
-            for device in devices_data["neo_devices"]
+            convert_to_dict(device, devices_sns) for device in neo_devices.values()
         ],
         "system_data": vars(system_data),
         "engineers": [vars(device) for _, device in engineers_data.__dict__.items()],

--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -63,9 +63,8 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
     @property
     def data(self) -> NeoStat | None:
         """Helper to get the data for the current device."""
-        (devices, _) = self.coordinator.data
-        neo_devices = {device.name: device for device in devices["neo_devices"]}
-        return neo_devices[self._neodevice.name]
+        (neo_devices, _) = self.coordinator.data
+        return neo_devices.get(self._neodevice.name, None)
 
     @property
     def system_data(self):
@@ -76,7 +75,9 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
     @property
     def available(self):
         """Returns whether the entity is available or not."""
-        return self.entity_description.availability_fn(self.data)
+        if self.data:
+            return self.entity_description.availability_fn(self.data)
+        return False
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -220,9 +220,8 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up button entities")
         return
 
-    devices_data, system_data = coordinator.data
+    neo_devices, system_data = coordinator.data
 
-    neo_devices = {device.name: device for device in devices_data["neo_devices"]}
     _LOGGER.info("Adding Neo Device Buttons")
 
     async_add_entities(

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -63,9 +63,7 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up sensor entities")
         return
 
-    devices_data, system_data = coordinator.data
-
-    neo_devices = {device.name: device for device in devices_data["neo_devices"]}
+    neo_devices, system_data = coordinator.data
 
     _LOGGER.info("Adding Neo Sensors")
 


### PR DESCRIPTION
This fixes the issue reported in #215 where if HA has an entity configured which is not being reported by the hub, you get errors in the logs and other devices fail to update as well. With this fix the entity will be marked unavailable instead.

Also implemented `async_unload_entry` which means one can enabled and disable entities without having to restart home assistant.