### PR TITLE
Added icons for timer/plug select

### DIFF
--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -27,6 +27,7 @@ class HeatmiserNeoEntityDescription(EntityDescription):
 
     setup_filter_fn: Callable[[NeoStat, Any], bool] = lambda dev, sys_data: True
     availability_fn: Callable[[NeoStat], bool] = lambda device: not device.offline
+    icon_fn: Callable[[NeoStat], str | None] | None = None
     # extra_attrs: list[str] | None = None
     custom_functions: (
         dict[str, Callable[[NeoStat, NeoHub, ServiceCall], Awaitable[None]]] | None
@@ -116,6 +117,13 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
     def should_poll(self) -> bool:
         """Don't poll - we fetch the data from the hub all at once."""
         return False
+
+    @property
+    def icon(self) -> str | None:
+        """Call icon function if defined."""
+        if self.entity_description.icon_fn:
+            return self.entity_description.icon_fn(self.data)
+        return None
 
     async def call_custom_action(self, service_call: ServiceCall) -> None:
         """Call a custom action specified in the entity description."""

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -130,6 +130,16 @@ def _timer_mode(device: NeoStat) -> ModeSelectOption:
     return ModeSelectOption.AUTO
 
 
+def _timer_icon(device: NeoStat) -> str | None:
+    if device.hold_on:
+        if device.hold_temp == 1:
+            return "mdi:timer-stop"
+        return "mdi:timer-stop-outline"
+    if device.standby:
+        return "mdi:timer-off-outline"
+    return "mdi:timer" if device.timer_on else "mdi:timer-outline"
+
+
 def _plug_mode(device: NeoStat) -> ModeSelectOption:
     if not device.manual_off:
         if device.timer_on:
@@ -140,6 +150,18 @@ def _plug_mode(device: NeoStat) -> ModeSelectOption:
             return ModeSelectOption.OVERRIDE_ON
         return ModeSelectOption.OVERRIDE_OFF
     return ModeSelectOption.AUTO
+
+
+def _plug_icon(device: NeoStat) -> str | None:
+    if not device.manual_off:
+        if device.timer_on:
+            return "mdi:toggle-switch-variant"
+        return "mdi:toggle-switch-variant-off"
+    if device.hold_on:
+        if device.hold_temp == 1:
+            return "mdi:timer-stop"
+        return "mdi:timer-stop-outline"
+    return "mdi:timer" if device.timer_on else "mdi:timer-outline"
 
 
 async def async_timer_hold(device: NeoStat, hub: NeoHub, service_call: ServiceCall):
@@ -189,6 +211,7 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
         set_value_fn=lambda mode, dev, hub: TIMER_SET_MODE.get(ModeSelectOption(mode))(
             dev, hub
         ),
+        icon_fn=_timer_icon,
         translation_key="timer_mode",
         custom_functions={SERVICE_TIMER_HOLD_ON: async_timer_hold},
     ),
@@ -201,6 +224,7 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
         set_value_fn=lambda mode, dev, hub: PLUG_SET_MODE.get(ModeSelectOption(mode))(
             dev, hub
         ),
+        icon_fn=_plug_icon,
         translation_key="plug_mode",
         custom_functions={SERVICE_TIMER_HOLD_ON: async_plug_hold},
     ),

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -40,14 +40,6 @@ from .entity import HeatmiserNeoEntity, HeatmiserNeoEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSORS_ENABLED = True
-OFFLINE_SENSOR_ENABLED = True
-ICON_BATTERY_LOW = "mdi:battery-low"
-ICON_BATTERY_OFF = "mdi:battery-off"
-ICON_BATTERY_FULL = "mdi:battery"
-ICON_NETWORK_OFFLINE = "mdi:network-off-outline"
-ICON_NETWORK_ONLINE = "mdi:network-outline"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
Small change to add nicer icons to the timer/plug mode select entity. For the timer they are based on `mdi:timer` with different icons used if the output is on or not, if override to on/off, standby etc. For the plug, if manual mode is used then it shows `toggle-switch-variant` on or off as required.

