### PR TITLE
Added config paramters for thermostats

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -9,7 +9,6 @@ import logging
 from neohubapi.neohub import NeoHub
 import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
@@ -25,6 +24,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CLIMATE,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
 ]

--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -23,6 +23,7 @@ from .const import (
     HEATMISER_TYPE_IDS_AWAY,
     HEATMISER_TYPE_IDS_HOLD,
     HEATMISER_TYPE_IDS_STANDBY,
+    HEATMISER_TYPE_IDS_THERMOSTAT,
     HEATMISER_TYPE_IDS_TIMER,
 )
 from .entity import HeatmiserNeoEntity, HeatmiserNeoEntityDescription
@@ -130,6 +131,17 @@ BINARY_SENSORS: tuple[HeatmiserNeoBinarySensorEntityDescription, ...] = (
         value_fn=lambda device: device.holiday,
         setup_filter_fn=lambda device, _: (
             device.device_type in HEATMISER_TYPE_IDS_AWAY
+        ),
+    ),
+    HeatmiserNeoBinarySensorEntityDescription(
+        key="heatmiser_neo_floor_limit",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        name="Floor Limit Reached",
+        value_fn=lambda device: device.floor_limit,
+        setup_filter_fn=lambda device, _: (
+            device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT
+            and not device.time_clock_mode
+            and device.current_floor_temperature < 127
         ),
     ),
 )

--- a/custom_components/heatmiserneo/icons.json
+++ b/custom_components/heatmiserneo/icons.json
@@ -1,0 +1,12 @@
+{
+  "entity": {
+    "select": {
+      "switching_differential": {
+        "default": "mdi:thermometer"
+      },
+      "preheat_time": {
+        "default": "mdi:progress-clock"
+      }
+    }
+  }
+}

--- a/custom_components/heatmiserneo/number.py
+++ b/custom_components/heatmiserneo/number.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+"""Heatmiser Neo Number platform."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from neohubapi.neohub import NeoHub, NeoStat
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import HeatmiserNeoConfigEntry
+from .const import HEATMISER_TEMPERATURE_UNIT_HA_UNIT, HEATMISER_TYPE_IDS_THERMOSTAT
+from .entity import HeatmiserNeoEntity, HeatmiserNeoEntityDescription
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HeatmiserNeoNumberEntityDescription(
+    HeatmiserNeoEntityDescription, NumberEntityDescription
+):
+    """Describes a number entity."""
+
+    value_fn: Callable[[NeoStat], Any]
+    set_value_fn: Callable[[HeatmiserNeoEntity, float], Awaitable[None]]
+    unit_of_measurement_fn: Callable[[NeoStat, Any], Any] | None = None
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HeatmiserNeoConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Heatmiser Neo number entities."""
+    hub = entry.runtime_data.hub
+    coordinator = entry.runtime_data.coordinator
+
+    if coordinator.data is None:
+        _LOGGER.error("Coordinator data is None. Cannot set up button entities")
+        return
+
+    neo_devices, system_data = coordinator.data
+
+    _LOGGER.info("Adding Neo Device Numbers")
+
+    async_add_entities(
+        HeatmiserNeoNumber(neodevice, coordinator, hub, description)
+        for description in NUMBERS
+        for neodevice in neo_devices.values()
+        if description.setup_filter_fn(neodevice, system_data)
+    )
+
+
+async def async_set_frost_temperature(entity: HeatmiserNeoEntity, val: float) -> None:
+    """Set the frost temperature on a device."""
+    message = {"SET_FROST": [val, [entity.data.name]]}
+    # TODO this should be in the API
+    await entity.coordinator.hub._send(message)  # noqa: SLF001
+    setattr(entity.data._data_, "FROST_TEMP", val)
+
+
+async def async_set_output_delay(entity: HeatmiserNeoEntity, val: float) -> None:
+    """Set the output delay on a device."""
+    message = {"SET_DELAY": [int(val), [entity.data.name]]}
+    # TODO this should be in the API
+    await entity.coordinator.hub._send(message)  # noqa: SLF001
+    setattr(entity.data._data_, "OUTPUT_DELAY", int(val))
+
+
+async def async_set_floor_limit(entity: HeatmiserNeoEntity, val: float) -> None:
+    """Set the floor limit temperature on a device."""
+    message = {"SET_FLOOR": [int(val), [entity.data.name]]}
+    # TODO this should be in the API
+    await entity.coordinator.hub._send(message)  # noqa: SLF001
+    setattr(entity.data._data_, "ENG_FLOOR_LIMIT", int(val))
+
+
+NUMBERS: tuple[HeatmiserNeoNumberEntityDescription, ...] = (
+    HeatmiserNeoNumberEntityDescription(
+        key="heatmiser_neo_frost_temp",
+        name="Frost Temperature",
+        device_class=NumberDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        setup_filter_fn=lambda device, _: (
+            device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT
+            and not device.time_clock_mode
+        ),
+        value_fn=lambda dev: dev._data_.FROST_TEMP,
+        set_value_fn=async_set_frost_temperature,
+        unit_of_measurement_fn=lambda _, sys_data: (
+            HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(sys_data.CORF, None)
+        ),
+        native_min_value=5,
+        native_max_value=17,
+        native_step=0.5,
+        mode=NumberMode.BOX,
+    ),
+    HeatmiserNeoNumberEntityDescription(
+        key="heatmiser_neo_output_delay",
+        name="Output Delay",
+        device_class=NumberDeviceClass.DURATION,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        setup_filter_fn=lambda device, _: (
+            device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT
+            and not device.time_clock_mode
+        ),
+        value_fn=lambda dev: dev._data_.OUTPUT_DELAY,
+        set_value_fn=async_set_output_delay,
+        native_min_value=0,
+        native_max_value=15,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        mode=NumberMode.BOX,
+    ),
+    HeatmiserNeoNumberEntityDescription(
+        key="heatmiser_neo_floor_limit_temp",
+        name="Floor Limit Temperature",
+        device_class=NumberDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        setup_filter_fn=lambda device, _: (
+            device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT
+            and not device.time_clock_mode
+            and device.current_floor_temperature < 127
+        ),
+        value_fn=lambda dev: dev._data_.ENG_FLOOR_LIMIT,
+        set_value_fn=async_set_floor_limit,
+        native_step=1,
+        unit_of_measurement_fn=lambda _, sys_data: (
+            HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(sys_data.CORF, None)
+        ),
+        mode=NumberMode.BOX,
+    ),
+)
+
+
+class HeatmiserNeoNumber(HeatmiserNeoEntity, NumberEntity):
+    """Heatmiser Neo number entity."""
+
+    def __init__(
+        self,
+        neostat: NeoStat,
+        coordinator: DataUpdateCoordinator,
+        hub: NeoHub,
+        entity_description: HeatmiserNeoNumberEntityDescription,
+    ) -> None:
+        """Initialize Heatmiser Neo number entity."""
+        super().__init__(
+            neostat,
+            coordinator,
+            hub,
+            entity_description,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the entity value to represent the entity state."""
+        return self.entity_description.value_fn(self.data)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Change the number."""
+        await self.entity_description.set_value_fn(self, value)
+        self.coordinator.async_update_listeners()
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement."""
+        if self.entity_description.unit_of_measurement_fn:
+            return self.entity_description.unit_of_measurement_fn(
+                self.data, self.system_data
+            )
+
+        return self.entity_description.native_unit_of_measurement

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -47,6 +47,24 @@
           "override_on": "Override On",
           "override_off": "Override Off"
         }
+      },
+      "switching_differential": {
+        "name": "Switching Differential",
+        "state": {
+          "0": "0.5°",
+          "1": "1°",
+          "2": "2°",
+          "3": "3°"
+        }
+      },
+      "preheat_time": {
+        "name": "Optimum Start",
+        "state": {
+          "0": "None",
+          "1": "1h",
+          "2": "2h",
+          "3": "3h"
+        }
       }
     }
   }

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -51,6 +51,24 @@
           "override_on": "Override On",
           "override_off": "Override Off"
         }
+      },
+      "switching_differential": {
+        "name": "Switching Differential",
+        "state": {
+          "0": "0.5°",
+          "1": "1°",
+          "2": "2°",
+          "3": "3°"
+        }
+      },
+      "preheat_time": {
+        "name": "Optimum Start",
+        "state": {
+          "0": "None",
+          "1": "1h",
+          "2": "2h",
+          "3": "3h"
+        }
       }
     }
   }


### PR DESCRIPTION
Added the following config parameters to thermostat entities:

![image](https://github.com/user-attachments/assets/4482f08e-477c-4948-bd50-74663a9fa620)

Thermostats with a floor sensor will additionally get the floor limit and also a binary sensor to show that the floor limit has been reached. These are not tested because I don't have any floor sensors connected to my stats.

Also haven't tested temperatures in Fahrenheit.

These config entities are disabled by default