### PR TITLE
Temporary Set Flag

### DIFF
--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -144,6 +144,16 @@ BINARY_SENSORS: tuple[HeatmiserNeoBinarySensorEntityDescription, ...] = (
             and device.current_floor_temperature < 127
         ),
     ),
+    HeatmiserNeoBinarySensorEntityDescription(
+        key="heatmiser_neo_temporary_set",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        name="Temporary Set",
+        value_fn=lambda device: device.temporary_set_flag,
+        setup_filter_fn=lambda device, _: (
+            device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
Added a diagnostic binary sensor representing the "TEMPORARY_SET_FLAG" from the heatmiser API. This is on/true if the temperature has been modified from the profile temperature (also set during hold):

![image](https://github.com/user-attachments/assets/79fa99d3-89b8-4a56-8d70-c6d693fc7194)

This is a quick win without adding profile support which will require changes in the NeoHub API