### PR TITLE
Beta7 fixes

### DIFF
--- a/custom_components/heatmiserneo/coordinator.py
+++ b/custom_components/heatmiserneo/coordinator.py
@@ -46,6 +46,11 @@ class HeatmiserNeoCoordinator(DataUpdateCoordinator[NeoHub]):
         async with asyncio.timeout(30):
             all_live_data = await self.hub.get_all_live_data()
 
+            if not all_live_data[ATTR_SYSTEM]:
+                ## System data is very important. If it is not returned by the API
+                ## Try getting it directly
+                all_live_data[ATTR_SYSTEM] = await self.hub.get_system()
+
             _LOGGER.debug("live_data: %s", all_live_data)
 
             devices = {device.name: device for device in all_live_data[ATTR_DEVICES]}

--- a/custom_components/heatmiserneo/manifest.json
+++ b/custom_components/heatmiserneo/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MindrustUK/Heatmiser-for-home-assistant/issues",
   "loggers": ["neohub"],
-  "requirements": ["neohubapi==2.3"],
+  "requirements": ["neohubapi==2.4"],
   "version": "v0.0.0",
   "zeroconf": [{ "type": "_hap._tcp.local.", "name": "heatmiser neohub*" }]
 }

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -358,6 +358,8 @@ def _profile_next_time(profile_id, entity: HeatmiserNeoSensor) -> str | None:
     profile_datetime = datetime.datetime.now().replace(
         hour=profile_time.hour,
         minute=profile_time.minute,
+        second=0,
+        microsecond=0,
         tzinfo=datetime.timezone(datetime.timedelta(minutes=tz * 60)),
     )
     if t < device_time:


### PR DESCRIPTION
@MindrustUK a few fixes for the Beta 7 release:

- If TIMESTAMP_SYSTEM is 0 on the live data, the new neo hub API won't request it. I will raise a PR to fix that as well, but added a protection here to fetch it if it is not returned by the api
- Next Profile time was changing every 30 seconds by a few seconds/microseconds so creating noise. 
- Fixed service calls when called with a device rather than an entity