### PR TITLE
Beta9 fixes

### DIFF
--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -32,6 +32,7 @@ from .entity import (
     HeatmiserNeoEntityDescription,
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
+    profile_sensor_enabled_by_default,
 )
 from .helpers import profile_level
 
@@ -187,6 +188,7 @@ BINARY_SENSORS: tuple[HeatmiserNeoBinarySensorEntityDescription, ...] = (
             device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT_NOT_HC
             and device.time_clock_mode
         ),
+        enabled_by_default_fn=profile_sensor_enabled_by_default,
     ),
 )
 

--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -170,10 +170,13 @@ def profile_level(
 
         flatten_fn = _flatten_timer_levels
         levels_filter = _timer_level_filter
-    elif profile_id == 0:
-        profile = coordinator.profiles_0.get(data.device_id)
     else:
-        profile = coordinator.profiles.get(int(profile_id))
+        if profile_format == ScheduleFormat.ZERO:
+            return None
+        if profile_id == 0:
+            profile = coordinator.profiles_0.get(data.device_id)
+        else:
+            profile = coordinator.profiles.get(int(profile_id))
 
     if hasattr(profile, "error") or not profile:
         return None

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -42,6 +42,7 @@ from .entity import (
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
     call_custom_action,
+    profile_sensor_enabled_by_default,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -411,6 +412,7 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
         set_value_fn=async_set_profile,
         name="Active Profile",
         # translation_key="preheat_time",
+        enabled_by_default_fn=profile_sensor_enabled_by_default,
     ),
     HeatmiserNeoSelectEntityDescription(
         key="heatmiser_neo_active_timer_profile",
@@ -427,6 +429,7 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
         set_value_fn=async_set_timer_profile,
         name="Active Profile",
         # translation_key="preheat_time",
+        enabled_by_default_fn=profile_sensor_enabled_by_default,
     ),
 )
 

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -42,6 +42,7 @@ from .entity import (
     HeatmiserNeoEntityDescription,
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
+    profile_sensor_enabled_by_default,
 )
 from .helpers import profile_level
 
@@ -231,6 +232,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
         unit_of_measurement_fn=lambda _, sys_data: (
             HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(sys_data.CORF, None)
         ),
+        enabled_by_default_fn=profile_sensor_enabled_by_default,
     ),
     HeatmiserNeoSensorEntityDescription(
         key="heatmiser_neo_profile_next_temp",
@@ -244,6 +246,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
         unit_of_measurement_fn=lambda _, sys_data: (
             HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(sys_data.CORF, None)
         ),
+        enabled_by_default_fn=profile_sensor_enabled_by_default,
     ),
     HeatmiserNeoSensorEntityDescription(
         key="heatmiser_neo_profile_next_time",
@@ -253,6 +256,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
         setup_filter_fn=lambda device, _: (
             device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT_NOT_HC
         ),
+        enabled_by_default_fn=profile_sensor_enabled_by_default,
     ),
 )
 

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -177,7 +177,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
         key="heatmiser_neo_stat_hold_temp",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="Hold Temperature",
-        value_fn=lambda device: device.data.hold_temp,
+        value_fn=lambda device: device.data.hold_temp if device.data.hold_on else None,
         setup_filter_fn=lambda device, sys_data: (
             (
                 device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT_NOT_HC
@@ -196,7 +196,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
         key="heatmiser_neo_stat_hold_temp_cool",
         device_class=SensorDeviceClass.TEMPERATURE,
         name="Hold Cooling Temperature",
-        value_fn=lambda device: device.data.hold_cool,
+        value_fn=lambda device: device.data.hold_cool if device.data.hold_on else None,
         setup_filter_fn=lambda device, sys_data: (
             device.device_type in HEATMISER_TYPE_IDS_HC
             and not device.time_clock_mode


### PR DESCRIPTION
A couple of fixes:

- Don't attempt to read profile data for thermostats if the format is ZERO (Non programmable)
- Disable profile entities for thermostats if hub is in non programmable mode (Timers are never in non programmable mode)