### PR TITLE
Away/Holiday service

### DIFF
--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -27,9 +27,13 @@ CONF_HVAC_MODES = "hvac_modes"
 SERVICE_HOLD_ON = "hold_on"
 SERVICE_HOLD_OFF = "hold_off"
 SERVICE_TIMER_HOLD_ON = "timer_hold_on"
+SERVICE_HUB_AWAY = "set_away_mode"
 ATTR_HOLD_DURATION = "hold_duration"
 ATTR_HOLD_STATE = "hold_state"
 ATTR_HOLD_TEMPERATURE = "hold_temperature"
+ATTR_AWAY_STATE = "away"
+# ATTR_AWAY_START = "start"
+ATTR_AWAY_END = "end"
 
 PROFILE_0 = "PROFILE_0"
 

--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -181,7 +181,7 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
                     _device_supports_away,
                 )
             if dev.holiday:
-                await self._hub.cancel_holiday(False)
+                await self._hub.cancel_holiday()
                 self.coordinator.update_in_memory_state(
                     partial(set_holiday, False),
                     _device_supports_away,

--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -14,9 +14,9 @@ def set_away(state: bool, dev: NeoStat) -> None:
         dev.target_temperature = dev._data_.FROST_TEMP
 
 
-def cancel_holiday(dev: NeoStat) -> None:
+def set_holiday(state: bool, dev: NeoStat) -> None:
     """Cancel holiday on device."""
-    dev.holiday = False
+    dev.holiday = state
 
 
 def _profile_current_day_key(

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -261,7 +261,6 @@ async def async_timer_hold(entity: HeatmiserNeoSelectEntity, service_call: Servi
     hold_minutes = int(duration.total_seconds() / 60)
     hold_minutes = min(hold_minutes, 60 * 99)
     await set_timer_override(entity, state, hold_minutes)
-    entity.coordinator.async_update_listeners()
 
 
 async def async_plug_hold(entity: HeatmiserNeoSelectEntity, service_call: ServiceCall):
@@ -271,7 +270,6 @@ async def async_plug_hold(entity: HeatmiserNeoSelectEntity, service_call: Servic
     hold_minutes = int(duration.total_seconds() / 60)
     hold_minutes = min(hold_minutes, 60 * 99)
     await set_plug_override(entity, state, hold_minutes)
-    entity.coordinator.async_update_listeners()
 
 
 async def async_set_switching_differential(

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -48,6 +48,8 @@ from .helpers import profile_level
 
 _LOGGER = logging.getLogger(__name__)
 
+HOLIDAY_FORMAT = "%a %b %d %H:%M:%S %Y\n"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -384,13 +386,11 @@ def _holiday_end(coordinator: HeatmiserNeoCoordinator) -> datetime.datetime | No
     holiday = coordinator.live_data.HUB_HOLIDAY
     holiday_end = coordinator.live_data.HOLIDAY_END
 
-    if not holiday:
+    if not holiday or holiday_end == 0:
         return None
 
     try:
-        parsed_datetime = datetime.datetime.strptime(
-            holiday_end, "%a %b %d %H:%M:%S %Y\n"
-        )
+        parsed_datetime = datetime.datetime.strptime(holiday_end, HOLIDAY_FORMAT)
         return parsed_datetime.replace(
             tzinfo=datetime.timezone(
                 datetime.timedelta(minutes=coordinator.system_data.TIME_ZONE * 60)

--- a/custom_components/heatmiserneo/services.yaml
+++ b/custom_components/heatmiserneo/services.yaml
@@ -52,3 +52,25 @@ timer_hold_on:
       default: true
       selector:
         boolean:
+set_away_mode:
+  name: Set Away Mode
+  description: Set Away/Holiday Mode on the Heatmiser NeoHub
+  target:
+    entity:
+      integration: heatmiserneo
+      domain: binary_sensor
+  fields:
+    away:
+      name: Away State
+      description: Whether to set away on or off
+      default: false
+      example: true
+      selector:
+        boolean:
+    end:
+      name: Holiday End
+      description: Optional end date for holiday mode
+      required: false
+      example: "2024-01-01 00:00:00"
+      selector:
+        datetime:


### PR DESCRIPTION
This PR adds a service to set/unset holiday/away mode. Hopefully this completes the requirements in #142.

![image](https://github.com/user-attachments/assets/0a8f37c6-8253-4593-809e-73b35471e3eb)

```
action: heatmiserneo.set_away_mode
data:
  away: true
  end: "2025-01-01 09:00:00"
target:
  entity_id: binary_sensor.neohub_192_168_80_10_away
```

There are three modes to call the service:

- Away set to false. This will turn off away and/or holiday
- Away set to true and no end date provided. Away mode will be enabled
- Away set to true and an end date is provided. Holiday mode will start and the end date will be set as defined.