### PR TITLE
Beta 13 fixes

### DIFF
--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -148,16 +148,16 @@ async def async_setup_entry(
     _LOGGER.info("Adding Neo Binary Sensors")
 
     async_add_entities(
+        HeatmiserNeoHubBinarySensor(coordinator, hub, description)
+        for description in HUB_BINARY_SENSORS
+        if description.setup_filter_fn(coordinator)
+    )
+
+    async_add_entities(
         HeatmiserNeoBinarySensor(neodevice, coordinator, hub, description)
         for description in BINARY_SENSORS
         for neodevice in neo_devices.values()
         if description.setup_filter_fn(neodevice, system_data)
-    )
-
-    async_add_entities(
-        HeatmiserNeoHubBinarySensor(coordinator, hub, description)
-        for description in HUB_BINARY_SENSORS
-        if description.setup_filter_fn(coordinator)
     )
 
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/heatmiserneo/button.py
+++ b/custom_components/heatmiserneo/button.py
@@ -46,16 +46,16 @@ async def async_setup_entry(
     _LOGGER.info("Adding Neo Device Buttons")
 
     async_add_entities(
+        HeatmiserNeoHubButton(coordinator, hub, description)
+        for description in HUB_BUTTONS
+        if description.setup_filter_fn(coordinator)
+    )
+
+    async_add_entities(
         HeatmiserNeoButton(neodevice, coordinator, hub, description)
         for description in BUTTONS
         for neodevice in neo_devices.values()
         if description.setup_filter_fn(neodevice, system_data)
-    )
-
-    async_add_entities(
-        HeatmiserNeoHubButton(coordinator, hub, description)
-        for description in HUB_BUTTONS
-        if description.setup_filter_fn(coordinator)
     )
 
 

--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -293,7 +293,7 @@ class NeoStatEntity(HeatmiserNeoEntity, ClimateEntity):
         # Centigrade
         if (
             float(self.data.temperature) < -50.0 or float(self.data.temperature) > 70.0
-        ) and self._unit_of_measurement == "C":
+        ) and self.temperature_unit == UnitOfTemperature.CELSIUS:
             _LOGGER.error(
                 "Error: Climate entity '%s' has an invalid current_temperature value: %s degrees Centigrade, Hub lost connection?",
                 self.data.name,
@@ -304,7 +304,7 @@ class NeoStatEntity(HeatmiserNeoEntity, ClimateEntity):
         # Fahrenheit
         if (
             float(self.data.temperature) < -58.0 or float(self.data.temperature) > 158.0
-        ) and self._unit_of_measurement == "F":
+        ) and self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             _LOGGER.error(
                 "Error: Climate entity '%s' has an invalid current_temperature value: %s degrees Fahrenheit, Hub lost connection?",
                 self.data.name,

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -510,19 +510,19 @@ async def async_setup_entry(
     _LOGGER.info("Adding Neo Select entities")
 
     async_add_entities(
+        HeatmiserNeoHubSelectEntity(coordinator, hub, description)
+        for description in HUB_SELECT
+        if description.setup_filter_fn(coordinator)
+    )
+
+    async_add_entities(
         HeatmiserNeoSelectEntity(neodevice, coordinator, hub, description)
         for description in SELECT
         for neodevice in neo_devices.values()
         if description.setup_filter_fn(neodevice, system_data)
     )
 
-    async_add_entities(
-        HeatmiserNeoHubSelectEntity(coordinator, hub, description)
-        for description in HUB_SELECT
-        if description.setup_filter_fn(coordinator)
-    )
     platform = entity_platform.async_get_current_platform()
-
     platform.async_register_entity_service(
         SERVICE_TIMER_HOLD_ON,
         {

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -70,16 +70,16 @@ async def async_setup_entry(
     _LOGGER.info("Adding Neo Sensors")
 
     async_add_entities(
+        HeatmiserNeoHubSensor(coordinator, hub, description)
+        for description in HUB_SENSORS
+        if description.setup_filter_fn(coordinator)
+    )
+
+    async_add_entities(
         HeatmiserNeoSensor(neodevice, coordinator, hub, description)
         for description in SENSORS
         for neodevice in neo_devices.values()
         if description.setup_filter_fn(neodevice, system_data)
-    )
-
-    async_add_entities(
-        HeatmiserNeoHubSensor(coordinator, hub, description)
-        for description in HUB_SENSORS
-        if description.setup_filter_fn(coordinator)
     )
 
 

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -7,6 +7,10 @@
         "data": {
           "host": "Host",
           "port": "Port"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of the NeoHub to connect to.",
+          "port": "The TCP port of the NeoHub to connect to (4242 for the Legacy API)."
         }
       }
     },

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -7,6 +7,10 @@
         "data": {
           "host": "Host",
           "port": "Port"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of the NeoHub to connect to.",
+          "port": "The TCP port of the NeoHub to connect to (4242 for the Legacy API)."
         }
       },
       "zeroconf_confirm": {


### PR DESCRIPTION
Three separate fixes:

- Fix for #234 - Fix an issue introduced when I refactored the code to use EntityDescriptors. The check for temperatures out of bounds was using an attribute which doesn't exist anymore
- When configuring the integration for the first time, a warning saying ```Detected that custom integration 'heatmiserneo' calls `device_registry.async_get_or_create` referencing a non existing `via_device` ('heatmiserneo', 'NEOHUB-SN:000000-192.168.80.10')``` would come up because the hub entities are created after the device entities. I changed it create the hub entities first which takes care of creating the hub device
- Improvement for #233 - There was some confusion as to what needed to be entered in the Host input box. Added descriptions to help users in the future:

![image](https://github.com/user-attachments/assets/59077020-38dc-4311-9805-783d46345325)
