### PR TITLE
Add Upsert mode to Profile Services

### DIFF
--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -48,7 +48,7 @@ ATTR_AWAY_END = "end"
 ATTR_NAME_OLD = "old_name"
 ATTR_NAME_NEW = "new_name"
 ATTR_FRIENDLY_MODE = "friendly_mode"
-ATTR_UPDATE = "update"
+ATTR_CREATE_MODE = "mode"
 ATTR_MONDAY_TIMES = "monday_times"
 ATTR_MONDAY_TEMPERATURES = "monday_temperatures"
 ATTR_TUESDAY_TIMES = "tuesday_times"
@@ -77,6 +77,16 @@ ATTR_SATURDAY_ON_TIMES = "saturday_on_times"
 ATTR_SATURDAY_OFF_TIMES = "saturday_off_times"
 ATTR_SUNDAY_ON_TIMES = "sunday_on_times"
 ATTR_SUNDAY_OFF_TIMES = "sunday_off_times"
+
+OPTION_CREATE_MODE_CREATE = "create"
+OPTION_CREATE_MODE_UPDATE = "update"
+OPTION_CREATE_MODE_UPSERT = "upsert"
+
+OPTIONS_CREATE_MODE = [
+    OPTION_CREATE_MODE_CREATE,
+    OPTION_CREATE_MODE_UPDATE,
+    OPTION_CREATE_MODE_UPSERT,
+]
 
 PROFILE_0 = "PROFILE_0"
 

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -478,9 +478,11 @@ def _convert_to_profile_info(
             f"Too many levels defined for {weekday}. Hub only supports {levels} levels"
         )
 
+    tuples = sorted([(list1[i], list2[i]) for i in range(len(list1))])
+
     return {
-        _convert_level_index(timer, levels, i): [list1[i], list2[i]]
-        if i < len(list1)
+        _convert_level_index(timer, levels, i): [tuples[i][0], tuples[i][1]]
+        if i < len(tuples)
         else [empty1, empty2]
         for i in range(levels)
     }

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -35,6 +35,7 @@ import homeassistant.util.dt as dt_util
 
 from . import HeatmiserNeoConfigEntry
 from .const import (
+    ATTR_CREATE_MODE,
     ATTR_FRIDAY_OFF_TIMES,
     ATTR_FRIDAY_ON_TIMES,
     ATTR_FRIDAY_TEMPERATURES,
@@ -62,7 +63,6 @@ from .const import (
     ATTR_TUESDAY_ON_TIMES,
     ATTR_TUESDAY_TEMPERATURES,
     ATTR_TUESDAY_TIMES,
-    ATTR_UPDATE,
     ATTR_WEDNESDAY_OFF_TIMES,
     ATTR_WEDNESDAY_ON_TIMES,
     ATTR_WEDNESDAY_TEMPERATURES,
@@ -73,6 +73,9 @@ from .const import (
     HEATMISER_TYPE_IDS_HOLD,
     HEATMISER_TYPE_IDS_THERMOSTAT,
     HEATMISER_TYPE_IDS_THERMOSTAT_NOT_HC,
+    OPTION_CREATE_MODE_CREATE,
+    OPTION_CREATE_MODE_UPDATE,
+    OPTIONS_CREATE_MODE,
     SERVICE_CREATE_PROFILE_ONE,
     SERVICE_CREATE_PROFILE_SEVEN,
     SERVICE_CREATE_PROFILE_TWO,
@@ -188,7 +191,9 @@ async def async_setup_entry(
         SERVICE_CREATE_PROFILE_ONE,
         {
             vol.Required(ATTR_NAME): cv.string,
-            vol.Optional(ATTR_UPDATE, default=False): cv.boolean,
+            vol.Optional(ATTR_CREATE_MODE, default=OPTION_CREATE_MODE_CREATE): vol.In(
+                OPTIONS_CREATE_MODE
+            ),
             vol.Required(ATTR_SUNDAY_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_SUNDAY_TEMPERATURES): vol.All(
                 cv.ensure_list, [vol.Coerce(float)]
@@ -200,7 +205,9 @@ async def async_setup_entry(
         SERVICE_CREATE_PROFILE_TWO,
         {
             vol.Required(ATTR_NAME): cv.string,
-            vol.Optional(ATTR_UPDATE, default=False): cv.boolean,
+            vol.Optional(ATTR_CREATE_MODE, default=OPTION_CREATE_MODE_CREATE): vol.In(
+                OPTIONS_CREATE_MODE
+            ),
             vol.Required(ATTR_MONDAY_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_MONDAY_TEMPERATURES): vol.All(
                 cv.ensure_list, [vol.Coerce(float)]
@@ -216,7 +223,9 @@ async def async_setup_entry(
         SERVICE_CREATE_PROFILE_SEVEN,
         {
             vol.Required(ATTR_NAME): cv.string,
-            vol.Optional(ATTR_UPDATE, default=False): cv.boolean,
+            vol.Optional(ATTR_CREATE_MODE, default=OPTION_CREATE_MODE_CREATE): vol.In(
+                OPTIONS_CREATE_MODE
+            ),
             vol.Required(ATTR_MONDAY_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_MONDAY_TEMPERATURES): vol.All(
                 cv.ensure_list, [vol.Coerce(float)]
@@ -252,7 +261,9 @@ async def async_setup_entry(
         SERVICE_CREATE_TIMER_PROFILE_ONE,
         {
             vol.Required(ATTR_NAME): cv.string,
-            vol.Optional(ATTR_UPDATE, default=False): cv.boolean,
+            vol.Optional(ATTR_CREATE_MODE, default=OPTION_CREATE_MODE_CREATE): vol.In(
+                OPTIONS_CREATE_MODE
+            ),
             vol.Required(ATTR_SUNDAY_ON_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_SUNDAY_OFF_TIMES): vol.All(cv.ensure_list, [time_str]),
         },
@@ -262,7 +273,9 @@ async def async_setup_entry(
         SERVICE_CREATE_TIMER_PROFILE_TWO,
         {
             vol.Required(ATTR_NAME): cv.string,
-            vol.Optional(ATTR_UPDATE, default=False): cv.boolean,
+            vol.Optional(ATTR_CREATE_MODE, default=OPTION_CREATE_MODE_CREATE): vol.In(
+                OPTIONS_CREATE_MODE
+            ),
             vol.Required(ATTR_MONDAY_ON_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_MONDAY_OFF_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_SUNDAY_ON_TIMES): vol.All(cv.ensure_list, [time_str]),
@@ -274,7 +287,9 @@ async def async_setup_entry(
         SERVICE_CREATE_TIMER_PROFILE_SEVEN,
         {
             vol.Required(ATTR_NAME): cv.string,
-            vol.Optional(ATTR_UPDATE, default=False): cv.boolean,
+            vol.Optional(ATTR_CREATE_MODE, default=OPTION_CREATE_MODE_CREATE): vol.In(
+                OPTIONS_CREATE_MODE
+            ),
             vol.Required(ATTR_MONDAY_ON_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_MONDAY_OFF_TIMES): vol.All(cv.ensure_list, [time_str]),
             vol.Required(ATTR_TUESDAY_ON_TIMES): vol.All(cv.ensure_list, [time_str]),
@@ -385,21 +400,24 @@ async def async_create_profile(
             f"Requested profile format ({requested_format}) does not match hub format ({profile_format})"
         )
 
-    is_update = service_call.data.get(ATTR_UPDATE, False)
+    create_mode = service_call.data.get(ATTR_CREATE_MODE, OPTION_CREATE_MODE_CREATE)
     profile_name = service_call.data[ATTR_NAME]
     profile_id, timer_profile = _check_profile_name(profile_name, coordinator)
 
     if not profile_id:
-        if is_update:
+        if create_mode == OPTION_CREATE_MODE_UPDATE:
             raise HomeAssistantError(
                 f"Could not find existing profile with name '{profile_name}'"
             )
-    elif not is_update:
-        raise HomeAssistantError(f"A profile with name '{profile_name}' already exists")
-    elif timer != timer_profile:
-        raise HomeAssistantError(
-            f"A {"heating" if timer else "timer"} profile with name '{profile_name}' already exists"
-        )
+    else:
+        if create_mode == OPTION_CREATE_MODE_CREATE:
+            raise HomeAssistantError(
+                f"A profile with name '{profile_name}' already exists"
+            )
+        if timer != timer_profile:
+            raise HomeAssistantError(
+                f"A {"heating" if timer else "timer"} profile with name '{profile_name}' already exists"
+            )
 
     heating_levels = 4 if timer else coordinator.system_data.HEATING_LEVELS
 
@@ -410,7 +428,7 @@ async def async_create_profile(
     }
 
     msg_details = {}
-    if is_update:
+    if profile_id:
         msg_details["ID"] = profile_id
     msg_details["info"] = weekday_levels
     msg_details["name"] = profile_name

--- a/custom_components/heatmiserneo/services.yaml
+++ b/custom_components/heatmiserneo/services.yaml
@@ -146,18 +146,24 @@ create_profile_one:
   fields:
     name:
       name: Profile Name
-      description: Profile Name. If update is false, it must not be in use already
+      description: Profile Name. If mode is Create, it must not be in use already
       required: true
       example: New Profile
       selector:
         text:
-    update:
-      name: Update
-      description: Set to true to update an existing profile
-      required: false
-      example: false
+    mode:
+      name: Mode
+      description: Choose the mode of operation
+      required: true
+      default: create
+      example: upsert
       selector:
-        boolean:
+        select:
+          options:
+            - "create"
+            - "update"
+            - "upsert"
+          translation_key: profile_create_mode
     sunday_times:
       name: Times
       description: Profile level time in HH:MM format
@@ -183,18 +189,24 @@ create_profile_two:
   fields:
     name:
       name: Profile Name
-      description: Profile Name. If update is false, it must not be in use already
+      description: Profile Name. If mode is Create, it must not be in use already
       required: true
       example: New Profile
       selector:
         text:
-    update:
-      name: Update
-      description: Set to true to update an existing profile
-      required: false
-      example: false
+    mode:
+      name: Mode
+      description: Choose the mode of operation
+      required: true
+      default: create
+      example: upsert
       selector:
-        boolean:
+        select:
+          options:
+            - "create"
+            - "update"
+            - "upsert"
+          translation_key: profile_create_mode
     monday_levels:
       collapsed: true
       fields:
@@ -242,18 +254,24 @@ create_profile_seven:
   fields:
     name:
       name: Profile Name
-      description: Profile Name. If update is false, it must not be in use already
+      description: Profile Name. If mode is Create, it must not be in use already
       required: true
       example: New Profile
       selector:
         text:
-    update:
-      name: Update
-      description: Set to true to update an existing profile
-      required: false
-      example: false
+    mode:
+      name: Mode
+      description: Choose the mode of operation
+      required: true
+      default: create
+      example: upsert
       selector:
-        boolean:
+        select:
+          options:
+            - "create"
+            - "update"
+            - "upsert"
+          translation_key: profile_create_mode
     monday_levels:
       collapsed: true
       fields:
@@ -396,18 +414,24 @@ create_timer_profile_one:
   fields:
     name:
       name: Profile Name
-      description: Profile Name. If update is false, it must not be in use already
+      description: Profile Name. If mode is Create, it must not be in use already
       required: true
       example: New Profile
       selector:
         text:
-    update:
-      name: Update
-      description: Set to true to update an existing profile
-      required: false
-      example: false
+    mode:
+      name: Mode
+      description: Choose the mode of operation
+      required: true
+      default: create
+      example: upsert
       selector:
-        boolean:
+        select:
+          options:
+            - "create"
+            - "update"
+            - "upsert"
+          translation_key: profile_create_mode
     sunday_on_times:
       name: Switch On Times
       description: Times to switch on in HH:MM format
@@ -433,18 +457,24 @@ create_timer_profile_two:
   fields:
     name:
       name: Profile Name
-      description: Profile Name. If update is false, it must not be in use already
+      description: Profile Name. If mode is Create, it must not be in use already
       required: true
       example: New Profile
       selector:
         text:
-    update:
-      name: Update
-      description: Set to true to update an existing profile
-      required: false
-      example: false
+    mode:
+      name: Mode
+      description: Choose the mode of operation
+      required: true
+      default: create
+      example: upsert
       selector:
-        boolean:
+        select:
+          options:
+            - "create"
+            - "update"
+            - "upsert"
+          translation_key: profile_create_mode
     monday_levels:
       collapsed: true
       fields:
@@ -492,18 +522,24 @@ create_timer_profile_seven:
   fields:
     name:
       name: Profile Name
-      description: Profile Name. If update is false, it must not be in use already
+      description: Profile Name. If mode is Create, it must not be in use already
       required: true
       example: New Profile
       selector:
         text:
-    update:
-      name: Update
-      description: Set to true to update an existing profile
-      required: false
-      example: false
+    mode:
+      name: Mode
+      description: Choose the mode of operation
+      required: true
+      default: create
+      example: upsert
       selector:
-        boolean:
+        select:
+          options:
+            - "create"
+            - "update"
+            - "upsert"
+          translation_key: profile_create_mode
     monday_levels:
       collapsed: true
       fields:

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -155,10 +155,10 @@
       "description": "Creates or update a profile for weekdays and weekends",
       "sections": {
         "monday_levels": {
-          "name": "Monday Levels"
+          "name": "Weekday Levels"
         },
         "sunday_levels": {
-          "name": "Sunday Levels"
+          "name": "Weekend Levels"
         }
       }
     },
@@ -194,10 +194,10 @@
       "description": "Creates or update a timer profile for weekdays and weekends",
       "sections": {
         "monday_levels": {
-          "name": "Monday Levels"
+          "name": "Weekday Levels"
         },
         "sunday_levels": {
-          "name": "Sunday Levels"
+          "name": "Weekend Levels"
         }
       }
     },
@@ -226,6 +226,15 @@
         "sunday_levels": {
           "name": "Sunday Levels"
         }
+      }
+    }
+  },
+  "selector": {
+    "profile_create_mode": {
+      "options": {
+        "create": "Create",
+        "update": "Update",
+        "upsert": "Upsert"
       }
     }
   }

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -159,10 +159,10 @@
       "description": "Creates or update a profile for weekdays and weekends",
       "sections": {
         "monday_levels": {
-          "name": "Monday Levels"
+          "name": "Weekday Levels"
         },
         "sunday_levels": {
-          "name": "Sunday Levels"
+          "name": "Weekend Levels"
         }
       }
     },
@@ -198,10 +198,10 @@
       "description": "Creates or update a timer profile for weekdays and weekends",
       "sections": {
         "monday_levels": {
-          "name": "Monday Levels"
+          "name": "Weekday Levels"
         },
         "sunday_levels": {
-          "name": "Sunday Levels"
+          "name": "Weekend Levels"
         }
       }
     },
@@ -230,6 +230,15 @@
         "sunday_levels": {
           "name": "Sunday Levels"
         }
+      }
+    }
+  },
+  "selector": {
+    "profile_create_mode": {
+      "options": {
+        "create": "Create",
+        "update": "Update",
+        "upsert": "Upsert"
       }
     }
   }

--- a/docs/services.md
+++ b/docs/services.md
@@ -131,7 +131,10 @@ This action allows creating or updating a heating profile. There are three versi
 These have the following parameters in common:
 
 - Name - The name of the profile to create or update
-- Update - If set to `false` (the default) the service will be in create mode and the supplied name must not exist already. If set to `true`, the supplied name must exist and it must be for a heating profile
+- Mode - Controls the operation mode. Options are:
+  - `create` - Create a new profile. Profile name must not already exist
+  - `update` - Updates an existing profile. The profile name must exist and the profile must be a heating profile (as opposed to a timer profile)
+  - `upsert` - Update or create a profile. If the profile name already exists, it must be for a heating profile (as opposed to a timer profile)
 - Times and Temperatures - Supply the times and temperatures for a particular weekday
   - Times must be supplied in `HH:MM` 24h format
   - Temperatures can be in 0.5 degree increments
@@ -146,7 +149,7 @@ You should target the NeoHub device itself or the Profile Format entity of the h
 action: heatmiserneo.create_profile_two
 data:
   name: Existing Profile
-  update: true
+  mode: upsert
   monday_times:
     - "06:45"
     - "09:00"
@@ -178,7 +181,10 @@ This action allows creating or updating a timer profile. There are three version
 These have the following parameters in common:
 
 - Name - The name of the profile to create or update
-- Update - If set to `false` (the default) the service will be in create mode and the supplied name must not exist already. If set to `true`, the supplied name must exist and it must be for a heating profile
+- Mode - Controls the operation mode. Options are:
+  - `create` - Create a new profile. Profile name must not already exist
+  - `update` - Updates an existing profile. The profile name must exist and the profile must be a timer profile (as opposed to a heating profile)
+  - `upsert` - Update or create a profile. If the profile name already exists, it must be for a timer profile (as opposed to a heating profile)
 - On Times and Off Times - Supply the times to turn on and off
   - Times must be supplied in `HH:MM` 24h format
   - For 24HR mode, supply `sunday_on_times` and `sunday_off_times`
@@ -192,7 +198,7 @@ You should target the NeoHub device itself or the Profile Format entity of the h
 action: heatmiserneo.create_timer_profile_two
 data:
   name: Existing Profile
-  update: true
+  mode: upsert
   monday_on_times:
     - "06:45"
     - "09:00"


### PR DESCRIPTION
As requested in [#109](https://github.com/MindrustUK/Heatmiser-for-home-assistant/issues/109#issuecomment-2612606259), added an upsert mode to the profile create services. The old `update` flag has been replaced by a `mode` with options of:

- `create`
- `update`
- `upsert`

Also ensured that profile levels are sorted before creating or updating profile