### PR TITLE
Configurable HVAC Modes for NeoStat HC

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -60,7 +60,16 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
     return True
+
+
+async def async_update_options(
+    hass: HomeAssistant, entry: HeatmiserNeoConfigEntry
+) -> None:
+    """Update options."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -144,6 +144,15 @@ class AvailableMode(str, enum.Enum):
     AUTO = "auto"
 
 
+class GlobalSystemType(str, enum.Enum):
+    """Global System Types for NeoStat HC."""
+
+    HEAT_ONLY = "HeatOnly"
+    COOL_ONLY = "CoolOnly"
+    HEAT_COOL = "HeatOrCool"
+    INDEPENDENT = "Independent"
+
+
 class ModeSelectOption(str, enum.Enum):
     """Operating mode options for NeoPlugs and NeoStats in timer mode."""
 

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -85,6 +85,7 @@ from .const import (
     SERVICE_DELETE_PROFILE,
     SERVICE_GET_PROFILE_DEFINITIONS,
     SERVICE_RENAME_PROFILE,
+    GlobalSystemType,
 )
 from .coordinator import HeatmiserNeoCoordinator
 from .entity import (
@@ -616,7 +617,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
                 device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT_NOT_HC
                 or (
                     device.device_type in HEATMISER_TYPE_IDS_HC
-                    and sys_data.GLOBAL_SYSTEM_TYPE != "CoolOnly"
+                    and sys_data.GLOBAL_SYSTEM_TYPE != GlobalSystemType.COOL_ONLY
                 )
             )
             and not device.time_clock_mode
@@ -633,7 +634,7 @@ SENSORS: tuple[HeatmiserNeoSensorEntityDescription, ...] = (
         setup_filter_fn=lambda device, sys_data: (
             device.device_type in HEATMISER_TYPE_IDS_HC
             and not device.time_clock_mode
-            and sys_data.GLOBAL_SYSTEM_TYPE != "HeatOnly"
+            and sys_data.GLOBAL_SYSTEM_TYPE != GlobalSystemType.HEAT_ONLY
         ),
         unit_of_measurement_fn=lambda _, sys_data: (
             HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(sys_data.CORF, None)

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -19,6 +19,9 @@
     }
   },
   "options": {
+    "abort": {
+      "no_devices_supported": "No devices have configurable HVAC modes"
+    },
     "step": {
       "init": {
         "title": "Configure HVAC Modes",
@@ -28,6 +31,11 @@
           "more": "Configure another device"
         },
         "description": "Select a device and configure the HVAC modes"
+      },
+      "none": {
+        "title": "Configure HVAC Modes",
+        "data": {},
+        "description": "No devices have configurable HVAC modes"
       }
     },
     "error": {}

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -23,6 +23,9 @@
     }
   },
   "options": {
+    "abort": {
+      "no_devices_supported": "No devices have configurable HVAC modes"
+    },
     "step": {
       "init": {
         "title": "Configure HVAC Modes",
@@ -32,6 +35,11 @@
           "more": "Configure another device"
         },
         "description": "Select a device and configure the HVAC modes"
+      },
+      "none": {
+        "title": "Configure HVAC Modes",
+        "data": {},
+        "description": "No devices have configurable HVAC modes"
       }
     },
     "error": {}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,45 +1,62 @@
 # Change Log
 
+## 20250129
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/251 by @ocrease, fixes issues with HVAC Mode configuration for NeoStat HC
+
 ## 20250126
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/248 by @ocrease, adds upsert mode to profile services.
 
 ## 20250124
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/247 by @ocrease, Improves NeoStatHC compatibility.
 
 ## 20250120
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/243 by @ocrease, changes to Zeroconf and Optimum start times.
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/246 by @ocrease, Adds service for programming thermostats.
 
 ## 20250116
+
 - Major release, version 3.0.0 now available. Massive thanks to @ocrease. This is a huge release, Please see previous notes for all changes.
 
 ## 20241230
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/235 by @ocrease, beta 13 fixes.
 
 ## 20241227
-- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/232 by @ocrease, documentation update. 
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/232 by @ocrease, documentation update.
 
 ## 20241224
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/231 by @ocrease, documentation improvements.
 
 ## 20241220
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/230 by @ocrease, combines away sensors, tweaks repeater button.
 
 ## 20241219
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/227 by @ocrease, adds service for holiday/away mode control.
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/228 by @ocrease, fixes naming of remove button.
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/229 by @ocrease, Add documentation using GitHub pages.
 
 ## 20241218
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/226 by @ocrease, fixes profile issues in beta9
 
 ## 20241217
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/225 by @ocrease, addresses issues with profiles not being available and other bugs in beta8.
 
 ## 20241212
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/224 by @ocrease, Bumps NeoHub API version and fixes issues in beta7.
 
 ## 20241212
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/223 by @ocrease, Bumps NeoHub API version and adds support for repeater and profile features.
 
 ## 20241206
@@ -67,7 +84,7 @@
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/213 by @ocrease, improves overall quality.
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/214 by @ocrease, fixing sensor type.
-- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/216 by @ocrease, improves robustness when devices are no longer avalible.
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/216 by @ocrease, improves robustness when devices are no longer available.
 
 ## 20241105
 

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -7,3 +7,7 @@ There are various features that have been developed but due to lack of devices t
 
 - NeoAir
 - NeoStatHC
+
+# NeoStat HC
+
+NeoStat HC thermostats can be configured to heat and/or cool. By default they also always have a fan mode. If the physical installation of the device does not support some modes, you can use the Configure option on the hub entry to override the available modes for each device. This only applies to NeoStat HC thermostats.


### PR DESCRIPTION
The Options Flow for configuring HVAC modes on thermostats was broken as reported in #249.

This PR fixes that and hopefully addresses the requirements in #78.

- Requirement 1 was already taken care of, only NeoStat HC devices support anything other than Heat
- Requirement 2 was supposed to be addressed by the existing Configure functionality but that was broken

With this PR, the Configure (Options) flow only shows NeoStat HCs. Then, depending on the `GLOBAL_SYSTEM_TYPE` configured on the hub, a list of available modes is shown to the user.

- If `HeatOnly`, Heat and Fan Only are options
- If `CoolOnly`, Cool and Fan Only are options
- Otherwise, all options are available - Heat, Cool, Auto, Fan Only

I haven't been able to fully test this since I don't have a NeoStat HC to test with