### PR TITLE
Fix for ZeroconfServiceInfo deprecation warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.9.5
     hooks:
       - id: ruff
         args:
@@ -8,14 +8,14 @@ repos:
       - id: ruff-format
         files: ^((custom_components)/.+)?[^/]+\.(py|pyi)$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args:
           - --ignore-words-list=astroid,checkin,hass,iif,NotIn
           - --quiet-level=2
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
         exclude: (.vscode|.devcontainer)

--- a/custom_components/heatmiserneo/config_flow.py
+++ b/custom_components/heatmiserneo/config_flow.py
@@ -10,7 +10,6 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components.climate import UnitOfTemperature
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
@@ -25,6 +24,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
     SelectSelectorMode,
 )
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import HeatmiserNeoConfigEntry, hold_duration_validation
 from .const import (

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20250206
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/257 by @ocrease, fixed ZeroconfServiceInfo deprecation warning
+
 ## 20250201
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/254 by @ocrease, improved options configuration flow


### PR DESCRIPTION
Simple fix by changing the import. 

Also updates precommit hook versions