### PR TITLE
Implement discovery using hubseek broadcast on port 19790

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
+from typing import Any
 
 from neohubapi.neohub import NeoHub
 import voluptuous as vol
@@ -12,8 +13,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType
 
+from .const import DISCOVER_SCAN_TIMEOUT, DISCOVERY_INTERVAL
 from .coordinator import HeatmiserNeoCoordinator
+from .discovery import (
+    async_discover_device,
+    async_discover_devices,
+    async_trigger_discovery,
+    async_update_entry_from_discovery,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,16 +49,40 @@ class HeatmiserNeoData:
     coordinator: HeatmiserNeoCoordinator
 
 
+async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
+    """Set up the Heatmiser Neo integration."""
+
+    async def _async_discovery(*_: Any) -> None:
+        async_trigger_discovery(
+            hass, await async_discover_devices(hass, DISCOVER_SCAN_TIMEOUT)
+        )
+
+    hass.async_create_background_task(
+        _async_discovery(), "heatmiserneo setup discovery"
+    )
+    async_track_time_interval(
+        hass, _async_discovery, DISCOVERY_INTERVAL, cancel_on_shutdown=True
+    )
+    return True
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: HeatmiserNeoConfigEntry,
 ) -> bool:
     """Set up Heatmiser Neo from a config entry."""
-
     # Set the Hub up to use and save
     host = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]
     token = entry.data.get(CONF_API_TOKEN)
+
+    if not entry.unique_id or entry.unique_id.count(":") != 5:
+        _LOGGER.debug(
+            "Unique id for %s is missing during setup or it is not a MAC address, trying to fill from discovery",
+            host,
+        )
+        if device := await async_discover_device(hass, host):
+            async_update_entry_from_discovery(hass, entry, device)
 
     # Make this configurable or retrieve from an API later.
     hub_serial_number = f"NEOHUB-SN:000000-{host}"

--- a/custom_components/heatmiserneo/api/__init__.py
+++ b/custom_components/heatmiserneo/api/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+"""To be included in neohub api."""

--- a/custom_components/heatmiserneo/api/discovery.py
+++ b/custom_components/heatmiserneo/api/discovery.py
@@ -1,0 +1,176 @@
+"""Discovery of Heatmiser Neo Hubs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+import json
+import logging
+import socket
+import time
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class NeoHubDetails:
+    """NeoHub details."""
+
+    mac_address: str
+    ip_address: str
+
+
+DISCOVERY_PORT = 19790
+
+
+def create_udp_socket(discovery_port: int) -> socket.socket:
+    """Create a udp socket used for communicating with the device."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.bind(("", discovery_port))
+    sock.setblocking(False)
+    return sock
+
+
+class HeatmiserDiscovery(asyncio.DatagramProtocol):
+    """UDP discovery protocol for Heatmiser Neo Hubs."""
+
+    def __init__(
+        self,
+        destination: tuple[str, int],
+        on_response: Callable[[bytes, tuple[str, int]], None],
+    ) -> None:
+        """Initialize Heatmiser Discovery."""
+        self.transport = None
+        self.destination = destination
+        self.on_response = on_response
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        """Trigger on_response callback with received data."""
+        self.on_response(data, addr)
+
+    def error_received(self, exc: Exception | None) -> None:
+        """Log any errors received during UDP communication."""
+        _LOGGER.error("HeatmiserDiscovery error: %s", exc)
+
+
+def decode_data(raw_response: bytes) -> NeoHubDetails | None:
+    """Decode a Heatmiser discovery response packet."""
+    try:
+        response = json.loads(raw_response.decode())
+        if {"ip", "device_id"} <= response.keys():
+            return NeoHubDetails(
+                mac_address=response["device_id"], ip_address=response["ip"]
+            )
+        _LOGGER.warning("Invalid device format: %s", response)
+    except json.JSONDecodeError:
+        _LOGGER.exception("Failed to decode response")
+    return None
+
+
+class AIOHeatmiserDiscovery:
+    """Asynchronous scanner for Heatmiser Neo Hubs."""
+
+    BROADCAST_FREQUENCY = 3
+    DISCOVER_MESSAGE = b"hubseek"
+    BROADCAST_ADDRESS = "<broadcast>"
+
+    def __init__(self) -> None:
+        """Initialize the AIOHeatmiserDiscovery scanner."""
+        self.found_devices: list[NeoHubDetails] = []
+
+    def _destination_from_address(self, address: str | None) -> tuple[str, int]:
+        if address is None:
+            address = self.BROADCAST_ADDRESS
+        return (address, DISCOVERY_PORT)
+
+    def _process_response(
+        self,
+        data: bytes | None,
+        from_address: tuple[str, int],
+        response_list: dict[tuple[str, int], NeoHubDetails],
+        specific_address: bool = False,
+    ) -> bool:
+        """Process a response.
+
+        Returns True if processing should stop
+        """
+        if data is None or data == self.DISCOVER_MESSAGE:
+            return False
+        try:
+            response_list[from_address] = decode_data(data)
+        except Exception:
+            _LOGGER.exception("Failed to decode response from %s", from_address)
+            return False
+        return specific_address
+
+    async def _async_run_scan(
+        self,
+        transport: asyncio.DatagramTransport,
+        destination: tuple[str, int],
+        timeout: int,
+        found_all_future: asyncio.Future[bool],
+    ) -> None:
+        """Send the scans."""
+        _LOGGER.debug("discover: %s => %s", destination, self.DISCOVER_MESSAGE)
+        transport.sendto(self.DISCOVER_MESSAGE, destination)
+        quit_time = time.monotonic() + timeout
+        remain_time = float(timeout)
+        while True:
+            time_out = min(remain_time, timeout / self.BROADCAST_FREQUENCY)
+            if time_out <= 0:
+                return
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(found_all_future), timeout=time_out
+                )
+            except TimeoutError:
+                if time.monotonic() >= quit_time:
+                    return
+                # No response, send broadcast again in cast it got lost
+                _LOGGER.debug("discover: %s => %s", destination, self.DISCOVER_MESSAGE)
+                transport.sendto(self.DISCOVER_MESSAGE, destination)
+            else:
+                return  # found_all
+            remain_time = quit_time - time.monotonic()
+
+    async def async_scan(
+        self, timeout: int = 10, address: str | None = None
+    ) -> list[NeoHubDetails]:
+        """Discover NeoHub devices."""
+        _LOGGER.debug("Starting NeoHub discovery with timeout %ds", timeout)
+        sock = create_udp_socket(DISCOVERY_PORT)
+        destination = self._destination_from_address(address)
+        found_all_future: asyncio.Future[bool] = asyncio.Future()
+        response_list: dict[tuple[str, int], NeoHubDetails] = {}
+
+        def _on_response(data: bytes, addr: tuple[str, int]) -> None:
+            _LOGGER.debug("discover: %s <= %s", addr, data)
+            if self._process_response(data, addr, response_list, address is not None):
+                found_all_future.set_result(True)
+
+        transport, _ = await asyncio.get_running_loop().create_datagram_endpoint(
+            lambda: HeatmiserDiscovery(
+                destination=destination,
+                on_response=_on_response,
+            ),
+            sock=sock,
+        )
+        try:
+            await self._async_run_scan(
+                transport,
+                destination,
+                timeout,
+                found_all_future,
+            )
+        finally:
+            transport.close()
+
+        self.found_devices = list(response_list.values())
+        _LOGGER.debug(
+            "Discovered %d NeoHub devices: %s",
+            len(self.found_devices),
+            self.found_devices,
+        )
+        return self.found_devices

--- a/custom_components/heatmiserneo/config_flow.py
+++ b/custom_components/heatmiserneo/config_flow.py
@@ -2,9 +2,11 @@
 
 """Config flow for Heatmiser Neo."""
 
+from __future__ import annotations
+
 from copy import deepcopy
 import logging
-from typing import Any
+from typing import Any, Self
 
 from neohubapi.neohub import NeoHub, NeoHubConnectionError
 import voluptuous as vol
@@ -14,6 +16,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFl
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.selector import (
     DurationSelector,
     DurationSelectorConfig,
@@ -25,8 +28,10 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.typing import DiscoveryInfoType
 
 from . import HeatmiserNeoConfigEntry, hold_duration_validation
+from .api.discovery import NeoHubDetails
 from .const import (
     CONF_CONN_METHOD_LEGACY,
     CONF_CONN_METHOD_WEBSOCKET,
@@ -43,14 +48,23 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_TIMER_HOLD_DURATION,
     DEFAULT_WEBSOCKET_PORT,
+    DISCOVER_SCAN_TIMEOUT,
     DOMAIN,
     HEATMISER_TEMPERATURE_UNIT_HA_UNIT,
     HEATMISER_TYPE_IDS_HC,
     AvailableMode,
     GlobalSystemType,
 )
+from .discovery import (
+    async_discover_device,
+    async_discover_devices,
+    async_update_entry_from_discovery,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+CONF_DEVICE = "device"
 
 
 class FlowHandler(ConfigFlow, domain=DOMAIN):
@@ -61,43 +75,33 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize Heatmiser Neo options flow."""
-        self._host = None
+        self.host = None
         self._port = None
         self._token = None
+        self._discovered_device: NeoHubDetails | None = None
+        self._discovered_devices: dict[str, NeoHubDetails] = {}
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         _LOGGER.debug("Zeroconfig discovered %s", discovery_info)
-        self._host = discovery_info.host
-        self._port = DEFAULT_PORT
 
-        await self.async_set_unique_id(f"{self._host}:{self._port}")
-        self._abort_if_unique_id_configured()
-        return await self.async_step_zeroconf_confirm()
+        if device := await async_discover_device(self.hass, discovery_info.host):
+            self._discovered_device = device
+            _LOGGER.debug(
+                "NeoHub discovered from zeroconf discovery: %s", self._discovered_device
+            )
+            return await self._async_handle_discovery()
+        self.host = discovery_info.host
 
-    async def async_step_zeroconf_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow initiated by zeroconf."""
-        _LOGGER.debug("context %s", self.context)
-        if user_input is not None:
-            conn_error = await self.try_connection()
-            if not conn_error:
-                return self._async_get_entry()
-            return self.async_abort(reason="cannot_connect")
-
-        return self.async_show_form(
-            step_id="zeroconf_confirm",
-            description_placeholders={"name": self._host},
-        )
+        return await self.async_step_choose_conn_method()
 
     async def try_connection(self):
         """Try connection to NeoHub."""
         _LOGGER.debug("Trying connection to NeoHub")
         try:
-            hub = NeoHub(self._host, self._port, token=self._token)
+            hub = NeoHub(self.host, self._port, token=self._token)
             await hub.firmware()
             await hub.disconnect()
         except NeoHubConnectionError:
@@ -107,11 +111,11 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
 
     @callback
     def _async_get_entry(self) -> ConfigFlowResult:
-        data = {CONF_HOST: self._host, CONF_PORT: self._port}
+        data = {CONF_HOST: self.host, CONF_PORT: self._port}
         if self._token:
             data[CONF_API_TOKEN] = self._token
         return self.async_create_entry(
-            title=f"{self._host}:{self._port}",
+            title=f"{self.host}:{self._port}",
             data=data,
         )
 
@@ -119,11 +123,25 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> tuple[ConfigFlowResult, dict[str, str]]:
         errors = {}
-        self._host = user_input[CONF_HOST]
+
+        if (
+            not self._discovered_device
+            or user_input[CONF_HOST] != self._discovered_device.ip_address
+        ):
+            if device := await async_discover_device(self.hass, user_input[CONF_HOST]):
+                self._discovered_device = device
+
+        self.host = user_input[CONF_HOST]
         self._port = user_input[CONF_PORT]
         self._token = user_input.get(CONF_API_TOKEN)
 
-        await self.async_set_unique_id(f"{self._host}:{self._port}")
+        if self._discovered_device:
+            await self.async_set_unique_id(
+                dr.format_mac(self._discovered_device.mac_address),
+                raise_on_progress=False,
+            )
+        else:
+            await self.async_set_unique_id(f"{self.host}:{self._port}")
         self._abort_if_unique_id_configured()
 
         conn_error = await self.try_connection()
@@ -136,19 +154,57 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle a flow initialized by the user."""
-        return self.async_show_menu(
+        """Handle the initial step."""
+        if user_input is not None:
+            if mac := user_input[CONF_DEVICE]:
+                await self.async_set_unique_id(mac, raise_on_progress=False)
+                self._discovered_device = self._discovered_devices[mac]
+            return await self.async_step_choose_conn_method()
+
+        current_unique_ids = self._async_current_ids()
+        current_hosts = {
+            entry.data[CONF_HOST]
+            for entry in self._async_current_entries(include_ignore=False)
+        }
+        discovered_devices = await async_discover_devices(
+            self.hass, DISCOVER_SCAN_TIMEOUT
+        )
+        self._discovered_devices = {
+            dr.format_mac(device.mac_address): device for device in discovered_devices
+        }
+        devices_name: dict[str | None, str] = {
+            mac: f"{device.mac_address} ({device.ip_address})"
+            for mac, device in self._discovered_devices.items()
+            if mac not in current_unique_ids and device.ip_address not in current_hosts
+        }
+        if not devices_name:
+            return await self.async_step_choose_conn_method()
+        devices_name[None] = "Manual Entry"
+        return self.async_show_form(
             step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_DEVICE): vol.In(devices_name)}),
+        )
+
+    async def async_step_choose_conn_method(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show menu to select websocket or legacy api."""
+        return self.async_show_menu(
+            step_id="choose_conn_method",
             menu_options=[CONF_CONN_METHOD_WEBSOCKET, CONF_CONN_METHOD_LEGACY],
+            # description_placeholders=_placeholders_from_device(self._discovered_device)
+            # if self._discovered_device
+            # else None,
         )
 
     async def async_step_conn_method_websocket(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle a flow initialized by the user."""
+        """Handle connection to websocket api."""
 
         errors = {}
         if user_input is not None:
+            user_input[CONF_PORT] = DEFAULT_WEBSOCKET_PORT
             result, errors = await self._configure_entry(user_input)
             if not errors:
                 return result
@@ -157,12 +213,13 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_HOST, default=self._host if self._host else DEFAULT_HOST
+                        CONF_HOST,
+                        default=self._discovered_device.ip_address
+                        if self._discovered_device
+                        else self.host
+                        if self.host
+                        else DEFAULT_HOST,
                     ): str,
-                    vol.Required(
-                        CONF_PORT,
-                        default=self._port if self._port else DEFAULT_WEBSOCKET_PORT,
-                    ): int,
                     vol.Required(CONF_API_TOKEN, default=self._token): str,
                 }
             ),
@@ -172,9 +229,18 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_conn_method_legacy(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle a flow initialized by the user."""
+        """Handle connection to legacy api."""
         errors = {}
-        if user_input is not None:
+
+        if self._discovered_device:
+            user_input = user_input if user_input else {}
+            user_input[CONF_HOST] = self._discovered_device.ip_address
+            user_input[CONF_PORT] = DEFAULT_PORT
+            result, errors = await self._configure_entry(user_input)
+            if not errors:
+                return result
+        elif user_input is not None:
+            user_input[CONF_PORT] = DEFAULT_PORT
             result, errors = await self._configure_entry(user_input)
             if not errors:
                 return result
@@ -184,15 +250,53 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_HOST, default=self._host if self._host else DEFAULT_HOST
-                    ): str,
-                    vol.Required(
-                        CONF_PORT, default=self._port if self._port else DEFAULT_PORT
-                    ): int,
+                        CONF_HOST,
+                        default=self._discovered_device.ip_address
+                        if self._discovered_device
+                        else self.host
+                        if self.host
+                        else DEFAULT_HOST,
+                    ): str
                 }
             ),
             errors=errors,
         )
+
+    async def async_step_integration_discovery(
+        self, discovery_info: DiscoveryInfoType
+    ) -> ConfigFlowResult:
+        """Handle integration discovery."""
+        self._discovered_device = NeoHubDetails(
+            discovery_info["mac_address"], discovery_info["ip_address"]
+        )
+        _LOGGER.debug(
+            "NeoHub discovered from integration discovery: %s", self._discovered_device
+        )
+        return await self._async_handle_discovery()
+
+    async def _async_handle_discovery(self) -> ConfigFlowResult:
+        """Handle any discovery."""
+        device = self._discovered_device
+        assert device is not None
+        mac = dr.format_mac(device.mac_address)
+        host = device.ip_address
+        await self.async_set_unique_id(mac)
+        for entry in self._async_current_entries(include_ignore=False):
+            if entry.unique_id == mac or entry.data[CONF_HOST] == host:
+                if async_update_entry_from_discovery(self.hass, entry, device):
+                    self.hass.config_entries.async_schedule_reload(entry.entry_id)
+                return self.async_abort(reason="already_configured")
+        self.host = host
+        if self.hass.config_entries.flow.async_has_matching_flow(self):
+            return self.async_abort(reason="already_in_progress")
+        # Handled ignored case since _async_current_entries
+        # is called with include_ignore=False
+        self._abort_if_unique_id_configured()
+        return await self.async_step_choose_conn_method()
+
+    def is_matching(self, other_flow: Self) -> bool:
+        """Return True if other_flow is matching this flow."""
+        return other_flow.host == self.host
 
     @staticmethod
     @callback

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 """Constants used by multiple Heatmiser Neo modules."""
 
+from datetime import timedelta
 import enum
 
 from homeassistant.components.climate import (
@@ -21,6 +22,9 @@ DEFAULT_WEBSOCKET_PORT = 4243
 DEFAULT_TIMER_HOLD_DURATION = 30
 DEFAULT_NEOSTAT_HOLD_DURATION = 30
 DEFAULT_NEOSTAT_TEMPERATURE_BOOST = 2
+
+DISCOVER_SCAN_TIMEOUT = 3
+DISCOVERY_INTERVAL = timedelta(minutes=15)
 
 CONF_CONN_METHOD_WEBSOCKET = "conn_method_websocket"
 CONF_CONN_METHOD_LEGACY = "conn_method_legacy"

--- a/custom_components/heatmiserneo/discovery.py
+++ b/custom_components/heatmiserneo/discovery.py
@@ -1,0 +1,100 @@
+"""Discovery of Heatmiser Neo Hubs."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict
+import logging
+
+from homeassistant import config_entries
+from homeassistant.components import network
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, discovery_flow
+
+from .api.discovery import AIOHeatmiserDiscovery, NeoHubDetails
+from .const import DISCOVER_SCAN_TIMEOUT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+_discovery_lock = asyncio.Lock()
+
+
+@callback
+def async_update_entry_from_discovery(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    device: NeoHubDetails,
+) -> bool:
+    """Update a config entry from a discovery."""
+    if not entry.unique_id or entry.unique_id.count(":") != 5:
+        _LOGGER.debug("Adding unique id from discovery: %s", device)
+        return hass.config_entries.async_update_entry(
+            entry, unique_id=dr.format_mac(device.mac_address)
+        )
+    _LOGGER.debug("Unique id is already present from discovery: %s", device)
+    return False
+
+
+async def async_discover_devices(
+    hass: HomeAssistant, timeout: int, address: str | None = None
+) -> list[NeoHubDetails]:
+    """Discover NeoHub devices."""
+
+    async with _discovery_lock:  # Use the module-level lock
+        if address:
+            targets = [address]
+        else:
+            targets = [
+                str(broadcast_address)
+                for broadcast_address in await network.async_get_ipv4_broadcast_addresses(
+                    hass
+                )
+            ]
+
+        scanner = AIOHeatmiserDiscovery()
+        combined_discoveries: dict[str, NeoHubDetails] = {}
+        for idx, discovered in enumerate(
+            await asyncio.gather(
+                *[
+                    scanner.async_scan(timeout=timeout, address=target_address)
+                    for target_address in targets
+                ],
+                return_exceptions=True,
+            )
+        ):
+            if isinstance(discovered, Exception):
+                _LOGGER.debug(
+                    "Scanning %s failed with error: %s", targets[idx], discovered
+                )
+                continue
+            if isinstance(discovered, BaseException):
+                raise discovered from None
+            for device in discovered:
+                assert isinstance(device, NeoHubDetails)
+                combined_discoveries[device.ip_address] = device
+
+        return list(combined_discoveries.values())
+
+
+async def async_discover_device(hass: HomeAssistant, host: str) -> NeoHubDetails | None:
+    """Direct discovery at a single ip instead of broadcast."""
+    # If we are missing the unique_id we should be able to fetch it
+    # from the device by doing a directed discovery at the host only
+    for device in await async_discover_devices(hass, DISCOVER_SCAN_TIMEOUT, host):
+        return device
+    return None
+
+
+@callback
+def async_trigger_discovery(
+    hass: HomeAssistant,
+    discovered_devices: list[NeoHubDetails],
+) -> None:
+    """Trigger config flows for discovered devices."""
+    for device in discovered_devices:
+        discovery_flow.async_create_flow(
+            hass,
+            DOMAIN,
+            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+            data=asdict(device),
+        )

--- a/custom_components/heatmiserneo/manifest.json
+++ b/custom_components/heatmiserneo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Heatmiser Neo Climate",
   "codeowners": ["@MindrustUK"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["network"],
   "documentation": "https://github.com/MindrustUK/Heatmiser-for-home-assistant",
   "integration_type": "hub",
   "iot_class": "local_polling",

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -2,7 +2,12 @@
   "config": {
     "step": {
       "user": {
-        "title": "Heatmiser Neo",
+        "description": "Select a discovered device, or Manual Entry",
+        "data": {
+          "device": "NeoHub"
+        }
+      },
+      "choose_conn_method": {
         "description": "Choose connection method",
         "menu_options": {
           "conn_method_websocket": "Use Websocket API",
@@ -11,37 +16,31 @@
       },
       "conn_method_websocket": {
         "description": "Set up Heatmiser Neo integration. Obtain an API Token from the Heatmiser app (Settings -> API).",
-        "title": "Heatmiser Neo",
         "data": {
           "host": "Host",
-          "port": "Port",
           "api_token": "API Token"
         },
         "data_description": {
           "host": "The hostname or IP address of the NeoHub to connect to.",
-          "port": "The TCP port of the NeoHub to connect to (4243 for the Websocket API).",
           "api_token": "The API token to access the NeoHub API"
         }
       },
       "conn_method_legacy": {
         "description": "Set up Heatmiser Neo integration. Enable Legacy API in the Heatmiser app (Settings -> API).",
-        "title": "Heatmiser Neo",
         "data": {
-          "host": "Host",
-          "port": "Port"
+          "host": "Host"
         },
         "data_description": {
-          "host": "The hostname or IP address of the NeoHub to connect to.",
-          "port": "The TCP port of the NeoHub to connect to (4242 for the Legacy API)."
+          "host": "The hostname or IP address of the NeoHub to connect to."
         }
-      },
-      "zeroconf_confirm": {
-        "description": "Do you want to add the Heatmiser Neo `{name}` to Home Assistant?",
-        "title": "Heatmiser Neo"
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "abort": {
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "already_configured": "This Hub is already configured"
     }
   },
   "options": {

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -2,7 +2,12 @@
   "config": {
     "step": {
       "user": {
-        "title": "Heatmiser Neo",
+        "description": "Select a discovered device, or Manual Entry",
+        "data": {
+          "device": "NeoHub"
+        }
+      },
+      "choose_conn_method": {
         "description": "Choose connection method",
         "menu_options": {
           "conn_method_websocket": "Use Websocket API",
@@ -11,37 +16,31 @@
       },
       "conn_method_websocket": {
         "description": "Set up Heatmiser Neo integration. Obtain an API Token from the Heatmiser app (Settings -> API).",
-        "title": "Heatmiser Neo",
         "data": {
           "host": "Host",
-          "port": "Port",
           "api_token": "API Token"
         },
         "data_description": {
           "host": "The hostname or IP address of the NeoHub to connect to.",
-          "port": "The TCP port of the NeoHub to connect to (4243 for the Websocket API).",
           "api_token": "The API token to access the NeoHub API"
         }
       },
       "conn_method_legacy": {
         "description": "Set up Heatmiser Neo integration. Enable Legacy API in the Heatmiser app (Settings -> API).",
-        "title": "Heatmiser Neo",
         "data": {
-          "host": "Host",
-          "port": "Port"
+          "host": "Host"
         },
         "data_description": {
-          "host": "The hostname or IP address of the NeoHub to connect to.",
-          "port": "The TCP port of the NeoHub to connect to (4242 for the Legacy API)."
+          "host": "The hostname or IP address of the NeoHub to connect to."
         }
-      },
-      "zeroconf_confirm": {
-        "description": "Do you want to add the Heatmiser Neo `{name}` to Home Assistant?",
-        "title": "Heatmiser Neo"
       }
     },
     "error": {
       "cannot_connect": "Failed to connect"
+    },
+    "abort": {
+      "already_in_progress": "Configuration flow is already in progress",
+      "already_configured": "This Hub is already configured"
     }
   },
   "options": {


### PR DESCRIPTION
This PR implements discovery using the heatmiser `hubseek` command via UDP broadcast on port 19790. Features:

- When the integration is loaded, `async_setup` does an initial scan and schedules a scan every 15 minutes. Note, the integration is only loaded if you already have at least one hub. Otherwise see below
- The `unique_id` of config entries is now the mac address (as reported by hubseek device_id). For existing entries where the unique id is not a mac address, we attempt to get the mac address using hubseek and update it if possible.
- For new installations, the integration will run discovery and if any devices are found, then the user is presented with the list of discovered devices plus the option to set up a manual entry. Selecting any of the options then shows the connection method menu (eg websocket or legacy). If no devices are discovered, or the discovered devices are already configured, then the user goes straight to the connection method menu (basically initiate Manual Entry flow)
- If a user attempts to add a device that is already configured, the config flow will be aborted.

Future tasks:

- Files in the `api` submodule will eventually be moved into the neohub api. They are here while we verify functionality and get some feedback.
- Need to remove the fake serial number of the hub that is used in the integration and update all entity unique ids to use the config entry unique id instead (effectively the mac address of the hub)

This PR delivers #50 and #197, a lays the groundwork for #195.

I'll start a v3.2.0-beta.x pre-release stream. 
