### PR TITLE
Fallback to websocket mac address when not using discovery

### DIFF
--- a/custom_components/heatmiserneo/config_flow.py
+++ b/custom_components/heatmiserneo/config_flow.py
@@ -105,17 +105,19 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         )
         return await self._async_handle_discovery()
 
-    async def try_connection(self):
+    async def try_connection(self) -> tuple[str | None, str]:
         """Try connection to NeoHub."""
         _LOGGER.debug("Trying connection to NeoHub")
+        mac_address = None
         try:
             hub = NeoHub(self.host, self._port, token=self._token)
             await hub.firmware()
+            mac_address = hub.mac_address
             await hub.disconnect()
         except NeoHubConnectionError:
-            return "cannot_connect"
+            return None, "cannot_connect"
         _LOGGER.debug("Connection Worked!")
-        return None
+        return mac_address, None
 
     @callback
     def _async_get_entry(self) -> ConfigFlowResult:
@@ -145,8 +147,34 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(f"{self.host}:{self._port}")
         self._abort_if_unique_id_configured()
 
-        conn_error = await self.try_connection()
+        mac_address, conn_error = await self.try_connection()
         if not conn_error:
+            if mac_address:
+                if not self._discovered_device:
+                    _LOGGER.debug(
+                        "Using MAC address %s from websocket connection as unique id",
+                        mac_address,
+                    )
+                    await self.async_set_unique_id(
+                        dr.format_mac(mac_address),
+                        raise_on_progress=False,
+                    )
+                    self._abort_if_unique_id_configured()
+                elif dr.format_mac(mac_address) != dr.format_mac(
+                    self._discovered_device.mac_address
+                ):
+                    return self.async_abort(
+                        reason="connect_mismatch",
+                        description_placeholders={
+                            "mac_address_expected": dr.format_mac(
+                                self._discovered_device.mac_address
+                            ),
+                            "ip_address_expected": self._discovered_device.ip_address,
+                            "mac_address_connected": dr.format_mac(mac_address),
+                            "ip_address_connected": self.host,
+                        },
+                    ), None
+
             return self._async_get_entry(), None
 
         errors["base"] = conn_error
@@ -220,13 +248,17 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                 mac_address=connect_details.mac_address,
                 ip_address=connect_details.ip_address,
             )
-        elif self._discovered_device.mac_address != connect_details.mac_address:
+        elif dr.format_mac(self._discovered_device.mac_address) != dr.format_mac(
+            connect_details.mac_address
+        ):
             return self.async_abort(
                 reason="auto_connect_mismatch",
                 description_placeholders={
-                    "mac_address_expected": self._discovered_device.mac_address,
+                    "mac_address_expected": dr.format_mac(
+                        self._discovered_device.mac_address
+                    ),
                     "ip_address_expected": self._discovered_device.ip_address,
-                    "mac_address_received": connect_details.mac_address,
+                    "mac_address_received": dr.format_mac(connect_details.mac_address),
                     "ip_address_received": connect_details.ip_address,
                 },
             )

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -52,6 +52,7 @@
       "already_configured": "This Hub is already configured",
       "auto_connect_timeout": "Connect button press not detected",
       "auto_connect_mismatch": "Connect button pressed on different hub. Expected hub {mac_address_expected}({ip_address_expected}), received {mac_address_received}({ip_address_received})",
+      "connect_mismatch": "MAC address of Hub does not match discovery. Expected hub {mac_address_expected}({ip_address_expected}), connected to {mac_address_connected}({ip_address_connected})",
       "no_devices_discovered": "No Hubs were discovered",
       "no_new_devices_discovered": "No new Hubs were discovered"
     },

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -52,6 +52,7 @@
       "already_configured": "This Hub is already configured",
       "auto_connect_timeout": "Connect button press not detected",
       "auto_connect_mismatch": "Connect button pressed on different hub. Expected hub {mac_address_expected}({ip_address_expected}), received {mac_address_received}({ip_address_received})",
+      "connect_mismatch": "MAC address of Hub does not match discovery. Expected hub {mac_address_expected}({ip_address_expected}), connected to {mac_address_connected}({ip_address_connected})",
       "no_devices_discovered": "No Hubs were discovered",
       "no_new_devices_discovered": "No new Hubs were discovered"
     },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/273 by @ocrease, implement discovery and connection using connect button. Stop using fake serial number, use mac address instead
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/274 by @ocrease, fix config flow error for hubseek discovery
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/275 by @ocrease, use mac address from web socket connection if not already retrieved via discovery
 
 ## 20250303
 


### PR DESCRIPTION
If a user sets up a hub manually (eg not using the connect button or hubseek discovery) and they use websockets, we can use the mac address reported in the websocket response as the config entry unique id. 

If they use the legacy API, if discovery works in the environment and the relevant hub is discovered (even when setting up manually), we will still use the mac address from discovery (in fact, we try to do this on startup for any existing config entries which don't have a mac address as the unique id). So the only scenario where the config entry unique id is not a mac address is if a user does a manual setup and discovery does not work on their environment (for example if the hub and HA are on different subnets). In this case we fallback to IP address and port.