### PR TITLE
Check host is not already configured

### DIFF
--- a/custom_components/heatmiserneo/config_flow.py
+++ b/custom_components/heatmiserneo/config_flow.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 from copy import deepcopy
 import logging
+import socket
 from typing import Any, Self
 
 from neohubapi.neohub import NeoHub, NeoHubConnectionError
@@ -18,6 +19,7 @@ from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.network import is_ip_address
 from homeassistant.helpers.selector import (
     DurationSelector,
     DurationSelectorConfig,
@@ -175,6 +177,9 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
                         },
                     ), None
 
+            for entry in self._async_current_entries(include_ignore=False):
+                if _host_is_same(entry.data[CONF_HOST], self.host):
+                    return self.async_abort(reason="already_configured"), None
             return self._async_get_entry(), None
 
         errors["base"] = conn_error
@@ -288,7 +293,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
 
         current_unique_ids = self._async_current_ids()
         current_hosts = {
-            entry.data[CONF_HOST]
+            _resolve_ip_address(entry.data[CONF_HOST])
             for entry in self._async_current_entries(include_ignore=False)
         }
         discovered_devices = await async_discover_devices(
@@ -419,7 +424,7 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         host = device.ip_address
         await self.async_set_unique_id(mac)
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.unique_id == mac or entry.data[CONF_HOST] == host:
+            if entry.unique_id == mac or _host_is_same(entry.data[CONF_HOST], host):
                 if async_update_entry_from_discovery(self.hass, entry, device):
                     self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
@@ -440,6 +445,17 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
+
+
+def _resolve_ip_address(host: str) -> str:
+    """Check if host1 and host2 are the same."""
+    host = host.split(":")[0]
+    return host if is_ip_address(host) else socket.gethostbyname(host)
+
+
+def _host_is_same(host1: str, host2: str) -> bool:
+    """Check if host1 and host2 are the same."""
+    return _resolve_ip_address(host1) == _resolve_ip_address(host2)
 
 
 class OptionsFlowHandler(OptionsFlow):

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20250310
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/277 by @ocrease, check host is not already configured. Also documentation updates for Discovery
+
 ## 20250309
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/273 by @ocrease, implement discovery and connection using connect button. Stop using fake serial number, use mac address instead

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -5,6 +5,24 @@ nav_order: 10
 
 # Troubleshooting
 
+## Automated discovery issues
+
+Automated discovery works using UPD broadcasts. If your Hub is on a different subnet/network to Home Assistant, this
+integration will not detect your hub unless your router unless the UDP broadcasts are specifically forwarded/relayed
+from the Hub subnet to the Home Assistant subnet. Details for each method are below:
+
+### Connect Button
+
+Hub discovery and auto connect using the connect button on the hub relies on UDP broadcasts from the hub on UDP port 1979
+
+### Heatmiser Discovery (eg hubseek)
+
+Heatmiser discovery relies on UDP broadcasts from the hub on UDP port 19790
+
+### Zeroconf/MDNS
+
+Zeroconf/MDNS discovery works on UDP port 5353
+
 ## I can't find my Neohub
 
 ### Try discovery using nmap
@@ -21,8 +39,6 @@ Note: If you discover the device via mdns/zeroconf then you can use the hostname
 
 ### Using Heatmiser Discovery
 
-Note: This will eventually be part of the setup process and done internally.
-
 - Start a listener in a terminal: `nc -ulk -p 19790`
 - Issue the discovery command `echo -n "hubseek" | nc -b -u 255.255.255.255 19790`
 
@@ -30,6 +46,8 @@ A response such as `hubseek{"ip":"192.168.0.2","device_id":"nn:nn:nn:nn:nn:nn"}`
 listening terminal.
 
 ## I can't connect to my Neohub
+
+- If you are using the "Connect Button" method and your hub is on a different subnet, make sure UDP broadcasts on port 1979 are forwarded to the Home Assistant subnet.
 
 - If you are not using token based authentication;
 
@@ -40,8 +58,6 @@ listening terminal.
   - `printf '{"INFO":0}\0' | nc YOUR_DEVICE_IP_HERE 4242`
 
 - If you are trying to authenticate using token based authentication;
-  - The following instructions are a placeholder for now and will be further expanded on once the integration better
-  - supports token based authentication via web sockets.
   - Ensure you are applying this configuration to a Heatmiser NeoHub 2 or later. The Version 1 Hub does not support this
     authentication mechanism.
   - Ensure that your token is correct, this can be checked in the Heatmiser mobile app under _SETTINGS_ -> _API_ ->


### PR DESCRIPTION
If discovery does not work, it was possible to set up the same hub twice, eg once via websockets and once via the legacy API (and again if there is a hostname associated with the IP address). This PR checks that the host is not already configured and does DNS resolution to convert the hostname to an ip address for the comparison.

Also some documentation updates