### PR TITLE
Issue281 - skip set_hvac_mode if already set to the requested value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.5
+    rev: v0.11.0
     hooks:
       - id: ruff
         args:

--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -236,6 +236,11 @@ class NeoStatEntity(HeatmiserNeoEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set hvac mode."""
         _LOGGER.info("%s : Executing set_hvac_mode() with: %s", self.name, hvac_mode)
+
+        if self.hvac_mode == hvac_mode:
+            _LOGGER.debug("hvac_mode is already %s", hvac_mode)
+            return None
+
         _LOGGER.debug("self.data: %s", self.data)
 
         ## HVACMode.OFF is now PRESET_STANDBY. Adding this for backwards compatibility temporarily.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20250418
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/282 by @ocrease, skip set_hvac_mode if already set to requested value
+
 ## 20250310
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/277 by @ocrease, check host is not already configured. Also documentation updates for Discovery


### PR DESCRIPTION
Fix for #281 

The HA Scene editor attempts to set the hvac_mode and temperature on climate entities to the current value. For hvac_mode this causes the reported issue because non NeoStat HC thermostats don't allow changing the hvac_mode. The service now skips execution if the requested mode is the same as the current mode.

Also had to update one of the pre-commit hooks after updating my HA dev environment to the latest