### PR TITLE
Handle case when engineers data is not reported by the hub

### DIFF
--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -38,6 +38,7 @@ class HeatmiserNeoEntityDescription(EntityDescription):
 
     setup_filter_fn: Callable[[NeoStat, Any], bool] = lambda dev, sys_data: True
     availability_fn: Callable[[NeoStat], bool] = lambda device: not device.offline
+    property_exists_fn: Callable[[NeoStat], bool] = lambda device: True
     enabled_by_default_fn: Callable[[HeatmiserNeoEntity], bool] | None = None
     icon_fn: Callable[[NeoStat], str | None] | None = None
     # extra_attrs: list[str] | None = None
@@ -136,7 +137,7 @@ class HeatmiserNeoEntity(CoordinatorEntity[HeatmiserNeoCoordinator]):
     @property
     def available(self):
         """Returns whether the entity is available or not."""
-        if self.data:
+        if self.data and self.entity_description.property_exists_fn(self.data):
             return self.entity_description.availability_fn(self.data)
         return False
 

--- a/custom_components/heatmiserneo/number.py
+++ b/custom_components/heatmiserneo/number.py
@@ -99,6 +99,7 @@ NUMBERS: tuple[HeatmiserNeoNumberEntityDescription, ...] = (
             and not device.time_clock_mode
         ),
         value_fn=lambda dev: dev._data_.FROST_TEMP,
+        property_exists_fn=lambda device: hasattr(device._data_, "FROST_TEMP"),
         set_value_fn=async_set_frost_temperature,
         unit_of_measurement_fn=lambda _, sys_data: (
             HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(sys_data.CORF, None)
@@ -119,6 +120,7 @@ NUMBERS: tuple[HeatmiserNeoNumberEntityDescription, ...] = (
             and not device.time_clock_mode
         ),
         value_fn=lambda dev: dev._data_.OUTPUT_DELAY,
+        property_exists_fn=lambda device: hasattr(device._data_, "OUTPUT_DELAY"),
         set_value_fn=async_set_output_delay,
         native_min_value=0,
         native_max_value=15,
@@ -137,6 +139,7 @@ NUMBERS: tuple[HeatmiserNeoNumberEntityDescription, ...] = (
             and device.current_floor_temperature < 127
         ),
         value_fn=lambda dev: dev._data_.ENG_FLOOR_LIMIT,
+        property_exists_fn=lambda device: hasattr(device._data_, "ENG_FLOOR_LIMIT"),
         set_value_fn=async_set_floor_limit,
         native_step=1,
         unit_of_measurement_fn=lambda _, sys_data: (
@@ -154,6 +157,7 @@ NUMBERS: tuple[HeatmiserNeoNumberEntityDescription, ...] = (
             and not device.time_clock_mode
         ),
         value_fn=lambda dev: dev._data_.USER_LIMIT,
+        property_exists_fn=lambda device: hasattr(device._data_, "USER_LIMIT"),
         set_value_fn=async_set_user_limit,
         native_step=1,
         native_min_value=0,

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -410,6 +410,9 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
         value_fn=lambda entity: str(
             getattr(entity.data._data_, "SWITCHING DIFFERENTIAL")
         ),
+        property_exists_fn=lambda device: hasattr(
+            device._data_, "SWITCHING DIFFERENTIAL"
+        ),
         set_value_fn=async_set_switching_differential,
         translation_key="switching_differential",
     ),
@@ -423,6 +426,7 @@ SELECT: Final[tuple[HeatmiserNeoSelectEntityDescription, ...]] = (
             and not device.time_clock_mode
         ),
         value_fn=lambda entity: str(entity.data._data_.MAX_PREHEAT),
+        property_exists_fn=lambda device: hasattr(device._data_, "MAX_PREHEAT"),
         set_value_fn=async_set_preheat,
         translation_key="preheat_time",
     ),
@@ -591,7 +595,8 @@ class HeatmiserNeoSelectEntity(HeatmiserNeoEntity, SelectEntity):
         super().__init__(neostat, coordinator, hub, entity_description, config_entry)
         if entity_description.options_fn:
             self._attr_options = entity_description.options_fn(self)
-        self._attr_current_option = entity_description.value_fn(self)
+        if self.available:
+            self._attr_current_option = entity_description.value_fn(self)
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -603,7 +608,8 @@ class HeatmiserNeoSelectEntity(HeatmiserNeoEntity, SelectEntity):
         """Handle updated data from the coordinator."""
         if self.entity_description.options_fn:
             self._attr_options = self.entity_description.options_fn(self)
-        self._attr_current_option = self.entity_description.value_fn(self)
+        if self.available:
+            self._attr_current_option = self.entity_description.value_fn(self)
         super()._handle_coordinator_update()
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## 20250425
 
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/287 by @ocrease, handle case when engineers data is not reported by the hub
+
+## 20250425
+
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/286 by @ocrease, improve robustness of diagnostics
 
 ## 20250418


### PR DESCRIPTION
Fix #284 (and probably #283)

These two issues seem to suggest that the properties that come from the engineering data are not available. I suspect the hub sometimes doesn't report this data, maybe when it has lost connectivity to the end device (in #284 they are NeoAir V3s). 

This change introduces a way to check that the property is reported and if its not it will mark the entity as unavailable.