### PR TITLE
Serial Number Fallback

### DIFF
--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -93,7 +93,7 @@ async def async_setup_entry(
     temperature_unit = HEATMISER_TEMPERATURE_UNIT_HA_UNIT.get(
         system_data.CORF, UnitOfTemperature.CELSIUS
     )
-    temperature_step = await hub.target_temperature_step
+    temperature_step = await hub.target_temperature_step()
 
     _LOGGER.info("Adding Neo Climate Entities")
 

--- a/custom_components/heatmiserneo/config_flow.py
+++ b/custom_components/heatmiserneo/config_flow.py
@@ -621,9 +621,7 @@ class OptionsFlowHandler(OptionsFlow):
                         CONF_DEFAULTS: self._defaults_config,
                     },
                 )
-        temperature_step = (
-            await self.config_entry.runtime_data.coordinator.hub.target_temperature_step
-        )
+        temperature_step = await self.config_entry.runtime_data.coordinator.hub.target_temperature_step()
         options_schema = vol.Schema(
             {
                 vol.Required(CONF_THERMOSTAT_OPTIONS): section(

--- a/custom_components/heatmiserneo/manifest.json
+++ b/custom_components/heatmiserneo/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MindrustUK/Heatmiser-for-home-assistant/issues",
   "loggers": ["neohub"],
-  "requirements": ["neohubapi==3.0"],
+  "requirements": ["neohubapi==3.1"],
   "version": "v0.0.0",
   "zeroconf": [{ "type": "_hap._tcp.local.", "name": "heatmiser neohub*" }]
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20250725
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/292 by @ocrease, workaround for non unique serial numbers
+
 ## 20250425
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/287 by @ocrease, handle case when engineers data is not reported by the hub


### PR DESCRIPTION
Fix for #291 

Some Hub Mini and/or NeoAir thermostats are reporting the same serial numbers for multiple devices which causes an issue with the unique id for entities and devices.

This PR uses the workaround introduced in neohubapi 3.1. If the same serial number is detected, for the second and further devices (sorted by device ID), append the device id to the serial number. In the example above, the first device (Downstairs) would get the original serial number 0000000lx, but the second device would get 0000000lx-2.