### PR TITLE
Cleanup backwards compatibility for HVAC mode

### DIFF
--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -243,33 +243,8 @@ class NeoStatEntity(HeatmiserNeoEntity, ClimateEntity):
 
         _LOGGER.debug("self.data: %s", self.data)
 
-        ## HVACMode.OFF is now PRESET_STANDBY. Adding this for backwards compatibility temporarily.
-        ## HA 2025.4 will remove the ability to set invalid HVAC modes anyway
-        if hvac_mode is HVACMode.OFF:
-            _LOGGER.warning(
-                "Standby is now a preset. Please use set_preset_mode instead"
-            )
-            return await self.async_set_preset_mode(PRESET_STANDBY)
-
         if self.data.device_type not in HEATMISER_TYPE_IDS_HC:
-            if self.data.standby:
-                _LOGGER.warning(
-                    "Standby is now a preset. Please use set_preset_mode instead"
-                )
-                await self.data.set_frost(False)
-                self.data.standby = False
-                self.coordinator.async_update_listeners()
-                return None
             raise HomeAssistantError("Only NeoStat HC devices allow changing HVAC_MODE")
-
-        if hvac_mode not in self.hvac_modes:
-            modes_str = ", ".join(self.hvac_modes)
-            _LOGGER.warning(
-                "Mode %s is not supported. Supported modes are [%s]",
-                hvac_mode,
-                modes_str,
-            )
-            return None
 
         hc_mode: HCMode = None
         if hvac_mode == HVACMode.HEAT:

--- a/custom_components/heatmiserneo/coordinator.py
+++ b/custom_components/heatmiserneo/coordinator.py
@@ -56,13 +56,6 @@ class HeatmiserNeoCoordinator(DataUpdateCoordinator[NeoHub]):
             devices = {device.name: device for device in all_live_data[ATTR_DEVICES]}
             return devices, all_live_data
 
-    def _get_device_sn(self, device_id: int) -> str:
-        """Get a device serial number by its device id."""
-
-        return self._device_serial_numbers.get(device_id, {}).get(
-            "serial_number", "UNKNOWN"
-        )
-
     def update_in_memory_state(
         self, action: Callable[[NeoStat], None], filter: Callable[[NeoStat], bool]
     ) -> None:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20250726
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/293 by @ocrease, remove backwards compatibility code for HVAC Mode
+
 ## 20250725
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/292 by @ocrease, workaround for non unique serial numbers


### PR DESCRIPTION
Fixes #259 Remove backwards compatibility code added when HVAC modes were converted to preset modes. This backwards compatibility no longer works as of HA 2025.7 (was expected to stop working in 2025.4), so it can be removed now.

Also deleted a function that is not used (I think it was moved to the neohub api)