### PR TITLE
Offer fix for error caused by old devices

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -12,14 +12,21 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.event import async_track_time_interval
+import homeassistant.helpers.issue_registry as ir
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DISCOVER_SCAN_TIMEOUT, DISCOVERY_INTERVAL, DOMAIN
+from .const import (
+    DISCOVER_SCAN_TIMEOUT,
+    DISCOVERY_INTERVAL,
+    DOMAIN,
+    ISSUE_ID_CLEANUP_OLD_DEVICES,
+)
 from .coordinator import HeatmiserNeoCoordinator
 from .discovery import (
     async_discover_device,
@@ -169,6 +176,22 @@ async def _async_migrate_unique_ids(
 
     # Migrate
     hub_updated = False
+
+    num_hub_devices = len([d for d in registry_devices.values() if not d.via_device_id])
+    if num_hub_devices > 1:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            ISSUE_ID_CLEANUP_OLD_DEVICES.format(entry_id=entry.entry_id),
+            is_fixable=True,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="cleanup_old_devices",
+            data={"entry_id": entry.entry_id},
+        )
+        raise HomeAssistantError(
+            f"Heatmiser Hub at {entry.data[CONF_HOST]}:{entry.data[CONF_PORT]} can't be configured because there are invalid devices"
+        )
+
     for reg_device in registry_devices.values():
         if not reg_device.via_device_id:
             identifier_key = None

--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -155,6 +155,8 @@ HEATMISER_TYPE_IDS_IDENTIFY = HEATMISER_TYPE_IDS_THERMOSTAT.union(
 ).difference(HEATMISER_TYPE_IDS_PLUG)
 HEATMISER_TYPE_IDS_LOCK = HEATMISER_TYPE_IDS_IDENTIFY
 
+ISSUE_ID_CLEANUP_OLD_DEVICES = "cleanup_old_devices_{entry_id}"
+
 
 # This should be in the neohubapi.neohub enums code
 class AvailableMode(str, enum.Enum):

--- a/custom_components/heatmiserneo/repairs.py
+++ b/custom_components/heatmiserneo/repairs.py
@@ -1,0 +1,72 @@
+"""Repairs flows for Home Connect."""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.device_registry as dr
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CleanupOldDevicesFlow(RepairsFlow):
+    """Handler for deleting old devices that shouldn't exist anymore."""
+
+    def __init__(self, entry_id: str) -> None:
+        """Initialize."""
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+
+            device_registry = dr.async_get(self.hass)
+
+            registry_devices = dr.async_entries_for_config_entry(
+                device_registry, entry.entry_id
+            )
+            hub_device_id = next(
+                iter({d.via_device_id for d in registry_devices if d.via_device_id})
+            )
+            non_hub_devices = [
+                d
+                for d in registry_devices
+                if not d.via_device_id and d.id != hub_device_id
+            ]
+            for d in non_hub_devices:
+                _LOGGER.debug("delete old device %s - %s", d.id, d.name)
+                device_registry.async_remove_device(d.id)
+
+            await self.hass.config_entries.async_reload(self._entry_id)
+
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict[str, str] | None
+) -> RepairsFlow:
+    """Create flow."""
+
+    entry_id = data["entry_id"]
+
+    if issue_id.startswith("cleanup_old_devices"):
+        return CleanupOldDevicesFlow(entry_id)
+
+    return ConfirmRepairFlow()

--- a/custom_components/heatmiserneo/strings.json
+++ b/custom_components/heatmiserneo/strings.json
@@ -334,5 +334,18 @@
         "vent": "Fan Only"
       }
     }
+  },
+  "issues": {
+    "cleanup_old_devices": {
+      "title": "Found old devices",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Found old devices",
+            "description": "Old versions of the integration set up devices incorrectly.\n\nSelect **Submit** to delete the old devices"
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/heatmiserneo/translations/en.json
+++ b/custom_components/heatmiserneo/translations/en.json
@@ -334,5 +334,18 @@
         "vent": "Fan Only"
       }
     }
+  },
+  "issues": {
+    "cleanup_old_devices": {
+      "title": "Found old devices",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Found old devices",
+            "description": "Old versions of the integration set up devices incorrectly.\n\nSelect **Submit** to delete the old devices"
+          }
+        }
+      }
+    }
   }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20250731
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/295 by @ocrease, raise issue and offer fix when old device entries are detected
+
 ## 20250726
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/293 by @ocrease, remove backwards compatibility code for HVAC Mode

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -3,6 +3,10 @@ title: Upgrade Guide
 nav_order: 9
 ---
 
+# Upgrade to 3.2.x
+
+[Issue 294](https://github.com/MindrustUK/Heatmiser-for-home-assistant/issues/294) was raised soon after the release of v3.2.1. There are still installations where the advice of the release on 20240928 to delete and re-configure the hub was not followed and this can cause an issue when upgrading to this version. In later releases (eg after v3.2.1), an issue is raised and a fix is offered to the user to automatically cleanup the old device entries. Users just need to accept the fix and the integration will start working again.
+
 # Upgrade 1.6 to 3.0
 
 This is a major upgrade with a lot of changes. The recommendation is to delete and re-add the integration config entry. This will be the cleanest solution, though you might need to clean up any existing references to old entities that have been renamed or replaced. The main climate entities (eg thermostats) should not have changed. You can choose to simply upgrade and then manually delete any entities that are not longer provided by the integration.


### PR DESCRIPTION
Integrations in use before the release on 20240928 will still have device entries that were not linked to a hub device if the user did not follow the advice to delete and re-add the hub. These old device entries caused an issue with the unique id migration logic in v3.2.1. This PR raises an HA issue to let the user automatically delete the old devices and everything should start to work again