### PR TITLE
Issue301 - Fix issue with timer profiles where some days are empty

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -61,6 +61,42 @@ class HeatmiserNeoData:
     coordinator: HeatmiserNeoCoordinator
 
 
+@dataclass
+class ProfileLevel:
+    """Base class for a profile level with a time."""
+
+    time: str
+
+
+@dataclass
+class TemperatureProfileLevel(ProfileLevel):
+    """Profile level for temperature settings."""
+
+    temperature: float
+
+
+@dataclass
+class HeatCoolTemperatureProfileLevel(TemperatureProfileLevel):
+    """Profile level for temperature settings."""
+
+    cool_temperature: float
+    enabled: bool
+
+
+@dataclass
+class TimerProfileLevel(ProfileLevel):
+    """Profile level for on/off states."""
+
+    state: bool
+
+
+@dataclass
+class RawTimerProfileLevel(ProfileLevel):
+    """Profile level for on/off states."""
+
+    end_time: str
+
+
 async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
     """Set up the Heatmiser Neo integration."""
 

--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import HeatmiserNeoConfigEntry
+from . import HeatmiserNeoConfigEntry, TimerProfileLevel
 from .const import (
     ATTR_AWAY_END,
     ATTR_AWAY_STATE,
@@ -340,6 +340,6 @@ class HeatmiserNeoHubBinarySensor(HeatmiserNeoHubEntity, BinarySensorEntity):
 def _profile_current_state(profile_id, entity: HeatmiserNeoEntity) -> bool | None:
     """Convert a profile id to current temperature."""
     level = profile_level(profile_id, entity.data, entity.coordinator)
-    if level:
-        return level[1]
+    if isinstance(level, TimerProfileLevel):
+        return level.state
     return None

--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -7,6 +7,13 @@ from enum import Enum
 from neohubapi.enums import ScheduleFormat, Weekday
 from neohubapi.neohub import NeoStat
 
+from . import (
+    HeatCoolTemperatureProfileLevel,
+    ProfileLevel,
+    RawTimerProfileLevel,
+    TemperatureProfileLevel,
+    TimerProfileLevel,
+)
 from .coordinator import HeatmiserNeoCoordinator
 
 
@@ -93,7 +100,9 @@ def _profile_previous_day_key(current_weekday: str, format: ScheduleFormat) -> W
                     return Weekday.SATURDAY
 
 
-def _profile_levels(profile, key: Weekday, filter) -> list:
+def _profile_levels(
+    profile, key: Weekday, timeclock: bool, filter
+) -> list[ProfileLevel]:
     info = None
     if hasattr(profile, "info"):
         info = profile.info
@@ -101,26 +110,45 @@ def _profile_levels(profile, key: Weekday, filter) -> list:
         # Profile 0
         info = profile.profiles[0]
     key_val = key.value
-    levels = getattr(info, key_val)
-    levels = [lv for lv in levels.__dict__.values() if filter(lv)]
-    return sorted(levels, key=lambda lv: lv[0])
+    tmpLevels = getattr(info, key_val)
+    levels: list[ProfileLevel]
+    if timeclock:
+        timerLevels = [
+            RawTimerProfileLevel(time=lv[0], end_time=lv[1])
+            for lv in tmpLevels.__dict__.values()
+        ]
+        levels = [lv for lv in timerLevels if filter(lv)]
+    else:
+        temperatureLevels = [
+            TemperatureProfileLevel(time=lv[0], temperature=float(lv[1]))
+            if len(lv) == 2
+            else HeatCoolTemperatureProfileLevel(
+                time=lv[0],
+                temperature=float(lv[1]),
+                cool_temperature=float(lv[2]),
+                enabled=bool(lv[3]),
+            )
+            for lv in tmpLevels.__dict__.values()
+        ]
+        levels = [lv for lv in temperatureLevels if filter(lv)]
+    return sorted(levels, key=lambda lv: lv.time)
 
 
-def _timer_level_filter(level):
-    if not _is_valid_time(level[0]):
+def _timer_level_filter(level: RawTimerProfileLevel):
+    if not _is_valid_time(level.time):
         return False
-    if level[0] == level[1]:
+    if level.time == level.end_time:
         return False
     return True
 
 
-def _heating_level_filter(level):
-    if not _is_valid_time(level[0]):
+def _heating_level_filter(level: TemperatureProfileLevel):
+    if not _is_valid_time(level.time):
         return False
-    if level[1] < 5:
+    if level.temperature < 5:
         return False
-    if len(level) > 2:
-        if level[2] < 5 and level[3]:
+    if isinstance(level, HeatCoolTemperatureProfileLevel):
+        if level.cool_temperature < 5 and level.enabled:
             return False
     return True
 
@@ -129,34 +157,43 @@ def _is_valid_time(time) -> bool:
     return not (time == "24:00" or time > "24:00")
 
 
-def _flatten_timer_levels(levels):
-    levels = [[[lv[0], True], [lv[1], False]] for lv in levels]
-    return [x for lvs in levels for x in lvs]
+def _flatten_timer_levels(
+    levels: list[ProfileLevel],
+) -> list[ProfileLevel]:
+    tmp_levels = [
+        [
+            TimerProfileLevel(time=lv.time, state=True),
+            TimerProfileLevel(time=lv.end_time, state=False),
+        ]
+        for lv in levels
+        if isinstance(lv, RawTimerProfileLevel)
+    ]
+    return [x for lvs in tmp_levels for x in lvs]
 
 
-def _current_level(time: str, levels):
+def _current_level(time: str, levels: list[ProfileLevel]) -> ProfileLevel | None:
     current = None
     for lv in levels:
-        if time < lv[0]:
+        if time < lv.time:
             return current
         current = lv
     return current
 
 
-def _next_level(time: str, levels):
+def _next_level(time: str, levels: list[ProfileLevel]) -> ProfileLevel | None:
     previous_time = None
     for lv in levels:
-        if previous_time and lv[0] < previous_time:
+        if previous_time and lv.time < previous_time:
             return lv
-        if time < lv[0]:
+        if time < lv.time:
             return lv
-        previous_time = lv[0]
+        previous_time = lv.time
     return None
 
 
 def profile_level(
     profile_id, data: NeoStat, coordinator: HeatmiserNeoCoordinator, next: bool = False
-) -> str | None:
+) -> ProfileLevel | None:
     """Convert a profile id to a name."""
     profile_format = coordinator.system_data.FORMAT
     device_time = data._data_.TIME
@@ -189,7 +226,9 @@ def profile_level(
         return None
 
     current_day_key = _profile_current_day_key(device_weekday, profile_format)
-    levels = _profile_levels(profile, current_day_key, levels_filter)
+    levels = _profile_levels(
+        profile, current_day_key, data.time_clock_mode, levels_filter
+    )
     if flatten_fn:
         levels = flatten_fn(levels)
     current_level = (
@@ -203,7 +242,7 @@ def profile_level(
             if next
             else _profile_previous_day_key(device_weekday, profile_format)
         )
-        levels = _profile_levels(profile, alt_key, levels_filter)
+        levels = _profile_levels(profile, alt_key, data.time_clock_mode, levels_filter)
         if flatten_fn:
             levels = flatten_fn(levels)
         if len(levels) == 0:
@@ -211,18 +250,24 @@ def profile_level(
         current_level = levels[0 if next else -1]
         if data.time_clock_mode and not next:
             previous_level = levels[-2]
-            if current_level[0] < previous_level[0] and current_level[0] > device_time:
+            if (
+                current_level.time < previous_level.time
+                and current_level.time > device_time
+            ):
                 ## Its just after midnight and we haven't reached the last profile time
                 ## so look at the one before
                 current_level = previous_level
-    elif data.time_clock_mode and next and current_level[0] == levels[0][0]:
+    elif data.time_clock_mode and next and current_level.time == levels[0].time:
         ## need to check previous day as well if its the first level
         alt_key = _profile_previous_day_key(device_weekday, profile_format)
-        levels = _profile_levels(profile, alt_key, levels_filter)
+        levels = _profile_levels(profile, alt_key, data.time_clock_mode, levels_filter)
         if flatten_fn:
             levels = flatten_fn(levels)
         previous_level = levels[-1]
-        if previous_level[0] < current_level[0] and previous_level[0] > device_time:
+        if (
+            previous_level.time < current_level.time
+            and previous_level.time > device_time
+        ):
             ## Its just after midnight and we haven't reached the last profile time
             ## so that is the next level
             current_level = previous_level

--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -246,6 +246,8 @@ def profile_level(
         if flatten_fn:
             levels = flatten_fn(levels)
         if len(levels) == 0:
+            if data.time_clock_mode and not next:
+                return TimerProfileLevel(time="00:00", state=False)
             return None
         current_level = levels[0 if next else -1]
         if data.time_clock_mode and not next:
@@ -263,6 +265,8 @@ def profile_level(
         levels = _profile_levels(profile, alt_key, data.time_clock_mode, levels_filter)
         if flatten_fn:
             levels = flatten_fn(levels)
+        if len(levels) == 0:
+            return current_level
         previous_level = levels[-1]
         if (
             previous_level.time < current_level.time

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -33,7 +33,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from . import HeatmiserNeoConfigEntry
+from . import HeatmiserNeoConfigEntry, ProfileLevel, TemperatureProfileLevel
 from .const import (
     ATTR_CREATE_MODE,
     ATTR_FRIDAY_OFF_TIMES,
@@ -810,26 +810,26 @@ class HeatmiserNeoHubSensor(HeatmiserNeoHubEntity, SensorEntity):
 def _profile_current_temp(profile_id, entity: HeatmiserNeoSensor) -> float | None:
     """Convert a profile id to current temperature."""
     level = profile_level(profile_id, entity.data, entity.coordinator)
-    if level:
-        return float(level[1])
+    if isinstance(level, TemperatureProfileLevel):
+        return level.temperature
     return None
 
 
 def _profile_next_temp(profile_id, entity: HeatmiserNeoSensor) -> float | None:
-    _, temp = _profile_next_level(profile_id, entity)
-    if temp:
-        return float(temp)
+    level = _profile_next_level(profile_id, entity)
+    if isinstance(level, TemperatureProfileLevel) and level.temperature:
+        return level.temperature
     return None
 
 
 def _profile_next_time(profile_id, entity: HeatmiserNeoSensor) -> str | None:
-    t, _ = _profile_next_level(profile_id, entity)
-    if not t:
+    level = _profile_next_level(profile_id, entity)
+    if not level:
         return None
     device_time = entity.data._data_.TIME
     if len(device_time) == 4:
         device_time = f"0{device_time}"
-    profile_time = datetime.datetime.strptime(t, "%H:%M")
+    profile_time = datetime.datetime.strptime(level.time, "%H:%M")
     tz = entity.coordinator.system_data.TIME_ZONE
     if entity.coordinator.system_data.DST_ON:
         tz = tz + 1
@@ -840,17 +840,14 @@ def _profile_next_time(profile_id, entity: HeatmiserNeoSensor) -> str | None:
         microsecond=0,
         tzinfo=datetime.timezone(datetime.timedelta(minutes=tz * 60)),
     )
-    if t < device_time:
+    if level.time < device_time:
         return profile_datetime + datetime.timedelta(days=1)
     return profile_datetime
 
 
-def _profile_next_level(profile_id, entity: HeatmiserNeoSensor):
+def _profile_next_level(profile_id, entity: HeatmiserNeoSensor) -> ProfileLevel | None:
     """Convert a profile id to next level."""
-    lv = profile_level(profile_id, entity.data, entity.coordinator, True)
-    if lv:
-        return lv[0], lv[1]
-    return None, None
+    return profile_level(profile_id, entity.data, entity.coordinator, True)
 
 
 def _holiday_end(coordinator: HeatmiserNeoCoordinator) -> datetime.datetime | None:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20251112
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/303 by @ocrease, fix issue with timer profiles where some days are empty
+
 ## 20251104
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/299 by @ocrease, add support for NeoStat Touch


### PR DESCRIPTION
There was a scenario with timer profiles where an error would occur if we hadn't reached the first time level of a particular day, but the previous day had no levels at all.

Fixes #301