### PR TITLE
Use standard HA remove device option and automatically add new devices

### DIFF
--- a/custom_components/heatmiserneo/__init__.py
+++ b/custom_components/heatmiserneo/__init__.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 """The Heatmiser Neo integration."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
 from typing import Any
 
-from neohubapi.neohub import NeoHub
+from neohubapi.neohub import NeoHub, NeoStat
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -25,6 +26,7 @@ from .const import (
     DISCOVER_SCAN_TIMEOUT,
     DISCOVERY_INTERVAL,
     DOMAIN,
+    HEATMISER_TYPE_IDS_REPEATER,
     ISSUE_ID_CLEANUP_OLD_DEVICES,
 )
 from .coordinator import HeatmiserNeoCoordinator
@@ -314,3 +316,51 @@ def _has_old_identifier(device: dr.DeviceEntry) -> bool:
 
 def _has_mac_identifier(device: dr.DeviceEntry) -> bool:
     return any(ident[0] == dr.CONNECTION_NETWORK_MAC for ident in device.identifiers)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: HeatmiserNeoConfigEntry, device: dr.DeviceEntry
+) -> bool:
+    """Remove devices from hub."""
+    if not device.via_device_id:
+        # Hub device can't be removed. Remove whole config entry instead
+        return False
+    sn = device.serial_number
+    devices, _ = config_entry.runtime_data.coordinator.data
+    matching_devices = [dev for dev in devices.values() if dev.serial_number == sn]
+    if matching_devices:
+        for dev in matching_devices:
+            if dev.device_type in HEATMISER_TYPE_IDS_REPEATER:
+                await config_entry.runtime_data.coordinator.hub.remove_repeater(
+                    dev.device_id
+                )
+            else:
+                await dev.remove()
+        return await _confirm_removal(
+            config_entry.runtime_data.coordinator, matching_devices
+        )
+    return True
+
+
+async def _confirm_removal(
+    coordinator: HeatmiserNeoCoordinator, devices: list[NeoStat]
+):
+    timeout = 30
+    poll_interval = 10
+    start_time = asyncio.get_running_loop().time()
+    removed_device_ids = {dev.device_id for dev in devices}
+    while True:
+        current_time = asyncio.get_running_loop().time()
+        elapsed = current_time - start_time
+
+        await coordinator.async_request_refresh()
+        updated_devices, _ = coordinator.data
+        updated_device_ids = {dev.device_id for dev in updated_devices.values()}
+
+        if len(removed_device_ids - updated_device_ids) == len(removed_device_ids):
+            return True
+
+        if elapsed >= timeout:
+            return False
+        # Sleep briefly to update progress smoothly
+        await asyncio.sleep(poll_interval)

--- a/custom_components/heatmiserneo/binary_sensor.py
+++ b/custom_components/heatmiserneo/binary_sensor.py
@@ -17,8 +17,8 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -42,6 +42,7 @@ from .entity import (
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
     _device_supports_away,
+    async_setup_entities,
     call_custom_action,
     profile_sensor_enabled_by_default,
 )
@@ -142,22 +143,30 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up sensor entities")
         return
 
-    neo_devices, _ = coordinator.data
-    system_data = coordinator.system_data
+    @callback
+    def hub_entities():
+        return [
+            HeatmiserNeoHubBinarySensor(coordinator, hub, description, entry)
+            for description in HUB_BINARY_SENSORS
+            if description.setup_filter_fn(coordinator)
+        ]
 
-    _LOGGER.info("Adding Neo Binary Sensors")
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            HeatmiserNeoBinarySensor(neodevice, coordinator, hub, description, entry)
+            for description in BINARY_SENSORS
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    async_add_entities(
-        HeatmiserNeoHubBinarySensor(coordinator, hub, description, entry)
-        for description in HUB_BINARY_SENSORS
-        if description.setup_filter_fn(coordinator)
-    )
-
-    async_add_entities(
-        HeatmiserNeoBinarySensor(neodevice, coordinator, hub, description, entry)
-        for description in BINARY_SENSORS
-        for neodevice in neo_devices.values()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass,
+        entry,
+        async_add_entities,
+        Platform.BINARY_SENSOR,
+        hub_entities,
+        device_entities,
     )
 
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/heatmiserneo/button.py
+++ b/custom_components/heatmiserneo/button.py
@@ -12,23 +12,19 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
-from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HeatmiserNeoConfigEntry
-from .const import (
-    HEATMISER_TYPE_IDS_IDENTIFY,
-    HEATMISER_TYPE_IDS_REPEATER,
-    HEATMISER_TYPE_IDS_THERMOSTAT,
-)
+from .const import HEATMISER_TYPE_IDS_IDENTIFY
 from .coordinator import HeatmiserNeoCoordinator
 from .entity import (
     HeatmiserNeoEntity,
     HeatmiserNeoEntityDescription,
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
+    async_setup_entities,
 )
 
 
@@ -45,22 +41,25 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up button entities")
         return
 
-    neo_devices, _ = coordinator.data
-    system_data = coordinator.system_data
+    @callback
+    def hub_entities():
+        return [
+            HeatmiserNeoHubButton(coordinator, hub, description, entry)
+            for description in HUB_BUTTONS
+            if description.setup_filter_fn(coordinator)
+        ]
 
-    _LOGGER.info("Adding Neo Device Buttons")
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            HeatmiserNeoButton(neodevice, coordinator, hub, description, entry)
+            for description in BUTTONS
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    async_add_entities(
-        HeatmiserNeoHubButton(coordinator, hub, description, entry)
-        for description in HUB_BUTTONS
-        if description.setup_filter_fn(coordinator)
-    )
-
-    async_add_entities(
-        HeatmiserNeoButton(neodevice, coordinator, hub, description, entry)
-        for description in BUTTONS
-        for neodevice in neo_devices.values()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.BUTTON, hub_entities, device_entities
     )
 
 
@@ -85,27 +84,6 @@ class HeatmiserNeoHubButtonEntityDescription(
     press_fn: Callable[[HeatmiserNeoCoordinator], Awaitable[None]]
 
 
-async def async_remove_repeater(entity: HeatmiserNeoEntity):
-    """Handle repeater removal."""
-    await entity.coordinator.hub.remove_repeater(entity.data.device_id)
-    _async_remove_from_registry(entity)
-
-
-async def async_remove_device(entity: HeatmiserNeoEntity):
-    """Handle device removal."""
-    await entity.data.remove()
-    _async_remove_from_registry(entity)
-
-
-def _async_remove_from_registry(entity: HeatmiserNeoEntity):
-    """Handle device removal from registry."""
-    device_registry = dr.async_get(entity.hass)
-    device_registry.async_update_device(
-        device_id=entity.device_entry.id,
-        remove_config_entry_id=entity.coordinator.config_entry.entry_id,
-    )
-
-
 BUTTONS: tuple[HeatmiserNeoButtonEntityDescription, ...] = (
     HeatmiserNeoButtonEntityDescription(
         key="heatmiser_neo_identify_button",
@@ -116,28 +94,7 @@ BUTTONS: tuple[HeatmiserNeoButtonEntityDescription, ...] = (
         ),
         press_fn=lambda dev: dev.data.identify(),
     ),
-    HeatmiserNeoButtonEntityDescription(
-        key="heatmiser_repeater_remove",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        name="Remove",
-        setup_filter_fn=lambda device, _: (
-            device.device_type in HEATMISER_TYPE_IDS_REPEATER
-        ),
-        press_fn=async_remove_repeater,
-    ),
-    HeatmiserNeoButtonEntityDescription(
-        key="heatmiser_remove",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-        name="Remove",
-        setup_filter_fn=lambda device, _: (
-            device.device_type in HEATMISER_TYPE_IDS_THERMOSTAT
-        ),
-        press_fn=async_remove_device,
-    ),
 )
-
 
 HUB_BUTTONS: tuple[HeatmiserNeoHubButtonEntityDescription, ...] = (
     HeatmiserNeoHubButtonEntityDescription(
@@ -175,7 +132,7 @@ class HeatmiserNeoHubButton(HeatmiserNeoHubEntity, ButtonEntity):
         self,
         coordinator: HeatmiserNeoCoordinator,
         hub: NeoHub,
-        entity_description: HeatmiserNeoButtonEntityDescription,
+        entity_description: HeatmiserNeoHubButtonEntityDescription,
         config_entry: HeatmiserNeoConfigEntry,
     ) -> None:
         """Initialize Heatmiser Neo button entity."""

--- a/custom_components/heatmiserneo/climate.py
+++ b/custom_components/heatmiserneo/climate.py
@@ -29,8 +29,8 @@ from homeassistant.components.climate import (
     HVACMode,
     UnitOfTemperature,
 )
-from homeassistant.const import ATTR_TEMPERATURE
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_TEMPERATURE, Platform
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -62,7 +62,11 @@ from .const import (
     AvailableMode,
     GlobalSystemType,
 )
-from .entity import HeatmiserNeoEntity, HeatmiserNeoEntityDescription
+from .entity import (
+    HeatmiserNeoEntity,
+    HeatmiserNeoEntityDescription,
+    async_setup_entities,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,7 +84,6 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up climate entities")
         return
 
-    neo_devices, _ = coordinator.data
     system_data = coordinator.system_data
 
     hvac_config = entry.options.get(CONF_HVAC_MODES, {})
@@ -101,25 +104,28 @@ async def async_setup_entry(
     )
     temperature_step = await hub.target_temperature_step()
 
-    _LOGGER.info("Adding Neo Climate Entities")
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            NeoStatEntity(
+                neodevice,
+                coordinator,
+                hub,
+                description,
+                entry,
+                temperature_unit,
+                float(temperature_step),
+                hvac_config.get(neodevice.name, None),
+                defaults,
+            )
+            for description in CLIMATE
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    async_add_entities(
-        NeoStatEntity(
-            neodevice,
-            coordinator,
-            hub,
-            description,
-            entry,
-            temperature_unit,
-            float(temperature_step),
-            hvac_config.get(name, None),
-            defaults,
-        )
-        for description in CLIMATE
-        for name, neodevice in neo_devices.items()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.CLIMATE, None, device_entities
     )
-
     platform = entity_platform.async_get_current_platform()
 
     platform.async_register_entity_service(

--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -3,20 +3,22 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from functools import partial
 import logging
 from typing import Any
 
 from neohubapi.neohub import ATTR_SYSTEM, NeoHub, NeoStat, ScheduleFormat
-from propcache import cached_property
+from propcache.api import cached_property
 
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import ServiceCall
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HeatmiserNeoConfigEntry, unique_id_is_mac
@@ -312,3 +314,67 @@ def profile_sensor_enabled_by_default(entity: HeatmiserNeoEntity) -> bool:
     ):
         return True
     return False
+
+
+async def async_setup_entities(
+    hass: HomeAssistant,
+    entry: HeatmiserNeoConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    domain: Platform,
+    hub_entity_callback: Callable[[], Sequence[HeatmiserNeoHubEntity]] | None,
+    device_entity_callback: Callable[[list[NeoStat]], Sequence[HeatmiserNeoEntity]]
+    | None,
+) -> None:
+    """Set up Heatmiser Neo button entities."""
+    coordinator = entry.runtime_data.coordinator
+    entity_registry = er.async_get(hass)
+
+    devices_added: set[str] = set()
+    entities_added: set[str] = set()
+
+    if hub_entity_callback:
+        _LOGGER.info("Adding %s %s hub entities", DOMAIN, domain)
+        hub_entities = hub_entity_callback()
+        async_add_entities(hub_entities)
+        entities_added |= {
+            entity.unique_id for entity in hub_entities if entity.unique_id
+        }
+    if device_entity_callback:
+
+        @callback
+        def add_entities() -> None:
+            nonlocal devices_added
+            nonlocal entities_added
+
+            neo_devices, _ = coordinator.data
+
+            new_devices = [
+                dev
+                for dev in neo_devices.values()
+                if dev.serial_number not in devices_added
+            ]
+            if new_devices:
+                _LOGGER.info("Adding %s %s entities", DOMAIN, domain)
+                entities = device_entity_callback(new_devices)
+                async_add_entities(entities)
+                devices_added |= {dev.serial_number for dev in new_devices}
+                entities_added |= {
+                    entity.unique_id for entity in entities if entity.unique_id
+                }
+            if len(devices_added) > len(neo_devices):
+                devices_added.clear()
+                devices_added |= {dev.serial_number for dev in neo_devices.values()}
+
+        entry.async_on_unload(coordinator.async_add_listener(add_entities))
+        add_entities()
+
+    deleted_entries = [
+        entity.entity_id
+        for entity in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if entity.domain == domain
+        and entity.platform == DOMAIN
+        and entity.unique_id
+        and entity.unique_id not in entities_added
+    ]
+    for entity_id in deleted_entries:
+        entity_registry.async_remove(entity_id)

--- a/custom_components/heatmiserneo/lock.py
+++ b/custom_components/heatmiserneo/lock.py
@@ -11,7 +11,7 @@ from typing import Any
 from neohubapi.neohub import NeoHub, NeoStat
 
 from homeassistant.components.lock import DOMAIN, LockEntity, LockEntityDescription
-from homeassistant.const import ATTR_CODE
+from homeassistant.const import ATTR_CODE, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,7 +19,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import HeatmiserNeoConfigEntry
 from .const import HEATMISER_TYPE_IDS_LOCK
 from .coordinator import HeatmiserNeoCoordinator
-from .entity import HeatmiserNeoEntity, HeatmiserNeoEntityDescription
+from .entity import (
+    HeatmiserNeoEntity,
+    HeatmiserNeoEntityDescription,
+    async_setup_entities,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,16 +41,17 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up lock entities")
         return
 
-    neo_devices, _ = coordinator.data
-    system_data = coordinator.system_data
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            HeatmiserNeoLockEntity(neodevice, coordinator, hub, description, entry)
+            for description in LOCKS
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    _LOGGER.info("Adding Neo Locks")
-
-    async_add_entities(
-        HeatmiserNeoLockEntity(neodevice, coordinator, hub, description, entry)
-        for description in LOCKS
-        for neodevice in neo_devices.values()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.LOCK, None, device_entities
     )
 
 

--- a/custom_components/heatmiserneo/number.py
+++ b/custom_components/heatmiserneo/number.py
@@ -14,14 +14,18 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import EntityCategory, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory, Platform, UnitOfTime
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HeatmiserNeoConfigEntry
 from .const import HEATMISER_TEMPERATURE_UNIT_HA_UNIT, HEATMISER_TYPE_IDS_THERMOSTAT
 from .coordinator import HeatmiserNeoCoordinator
-from .entity import HeatmiserNeoEntity, HeatmiserNeoEntityDescription
+from .entity import (
+    HeatmiserNeoEntity,
+    HeatmiserNeoEntityDescription,
+    async_setup_entities,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,16 +54,17 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up button entities")
         return
 
-    neo_devices, _ = coordinator.data
-    system_data = coordinator.system_data
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            HeatmiserNeoNumber(neodevice, coordinator, hub, description, entry)
+            for description in NUMBERS
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    _LOGGER.info("Adding Neo Device Numbers")
-
-    async_add_entities(
-        HeatmiserNeoNumber(neodevice, coordinator, hub, description, entry)
-        for description in NUMBERS
-        for neodevice in neo_devices.values()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.NUMBER, None, device_entities
     )
 
 

--- a/custom_components/heatmiserneo/select.py
+++ b/custom_components/heatmiserneo/select.py
@@ -14,7 +14,7 @@ from neohubapi.neohub import NeoHub, NeoStat
 import voluptuous as vol
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
@@ -45,6 +45,7 @@ from .entity import (
     HeatmiserNeoEntityDescription,
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
+    async_setup_entities,
     call_custom_action,
     profile_sensor_enabled_by_default,
 )
@@ -541,22 +542,25 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up button entities")
         return
 
-    neo_devices, _ = coordinator.data
-    system_data = coordinator.system_data
+    @callback
+    def hub_entities():
+        return [
+            HeatmiserNeoHubSelectEntity(coordinator, hub, description, entry)
+            for description in HUB_SELECT
+            if description.setup_filter_fn(coordinator)
+        ]
 
-    _LOGGER.info("Adding Neo Select entities")
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            HeatmiserNeoSelectEntity(neodevice, coordinator, hub, description, entry)
+            for description in SELECT
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    async_add_entities(
-        HeatmiserNeoHubSelectEntity(coordinator, hub, description, entry)
-        for description in HUB_SELECT
-        if description.setup_filter_fn(coordinator)
-    )
-
-    async_add_entities(
-        HeatmiserNeoSelectEntity(neodevice, coordinator, hub, description, entry)
-        for description in SELECT
-        for neodevice in neo_devices.values()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.SELECT, hub_entities, device_entities
     )
 
     platform = entity_platform.async_get_current_platform()

--- a/custom_components/heatmiserneo/sensor.py
+++ b/custom_components/heatmiserneo/sensor.py
@@ -25,8 +25,8 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import ATTR_NAME, EntityCategory, UnitOfTime
-from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.const import ATTR_NAME, EntityCategory, Platform, UnitOfTime
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
@@ -93,6 +93,7 @@ from .entity import (
     HeatmiserNeoEntityDescription,
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
+    async_setup_entities,
     call_custom_action,
     profile_sensor_enabled_by_default,
 )
@@ -156,22 +157,25 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up sensor entities")
         return
 
-    neo_devices, _ = coordinator.data
-    system_data = coordinator.system_data
+    @callback
+    def hub_entities():
+        return [
+            HeatmiserNeoHubSensor(coordinator, hub, description, entry)
+            for description in HUB_SENSORS
+            if description.setup_filter_fn(coordinator)
+        ]
 
-    _LOGGER.info("Adding Neo Sensors")
+    @callback
+    def device_entities(new_devices: list[NeoStat]):
+        return [
+            HeatmiserNeoSensor(neodevice, coordinator, hub, description, entry)
+            for description in SENSORS
+            for neodevice in new_devices
+            if description.setup_filter_fn(neodevice, coordinator.system_data)
+        ]
 
-    async_add_entities(
-        HeatmiserNeoHubSensor(coordinator, hub, description, entry)
-        for description in HUB_SENSORS
-        if description.setup_filter_fn(coordinator)
-    )
-
-    async_add_entities(
-        HeatmiserNeoSensor(neodevice, coordinator, hub, description, entry)
-        for description in SENSORS
-        for neodevice in neo_devices.values()
-        if description.setup_filter_fn(neodevice, system_data)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.SENSOR, hub_entities, device_entities
     )
 
     platform = entity_platform.async_get_current_platform()
@@ -795,7 +799,7 @@ class HeatmiserNeoHubSensor(HeatmiserNeoHubEntity, SensorEntity):
         self,
         coordinator: HeatmiserNeoCoordinator,
         hub: NeoHub,
-        entity_description: HeatmiserNeoSensorEntityDescription,
+        entity_description: HeatmiserNeoHubSensorEntityDescription,
         config_entry: HeatmiserNeoConfigEntry,
     ) -> None:
         """Initialize Heatmiser Neo button entity."""

--- a/custom_components/heatmiserneo/switch.py
+++ b/custom_components/heatmiserneo/switch.py
@@ -9,7 +9,8 @@ import logging
 from neohubapi.neohub import NeoHub, NeoStat
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HeatmiserNeoConfigEntry
@@ -18,6 +19,7 @@ from .entity import (
     HeatmiserNeoEntityDescription,
     HeatmiserNeoHubEntity,
     HeatmiserNeoHubEntityDescription,
+    async_setup_entities,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,12 +38,16 @@ async def async_setup_entry(
         _LOGGER.error("Coordinator data is None. Cannot set up sensor entities")
         return
 
-    _LOGGER.info("Adding Neo Switches")
+    @callback
+    def hub_entities():
+        return [
+            HeatmiserNeoHubSwitch(coordinator, hub, description, entry)
+            for description in HUB_SWITCHES
+            if description.setup_filter_fn(coordinator)
+        ]
 
-    async_add_entities(
-        HeatmiserNeoHubSwitch(coordinator, hub, description, entry)
-        for description in HUB_SWITCHES
-        if description.setup_filter_fn(coordinator)
+    await async_setup_entities(
+        hass, entry, async_add_entities, Platform.SWITCH, hub_entities, None
     )
 
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -24,3 +24,11 @@ For other devices (thermostats, timers, plugs or other accessories), you first h
 Then again you have 120 seconds to perform the actions on the device itself. Consult the manual of the device to find out the steps that are required.
 
 If the new device is detected within the 120 seconds, you will get a confirmation and the integration will be reloaded to include the new device.
+
+Devices added using the Heatmiser App or other external method will automatically be added to the integration once they are detected.
+
+# Removing devices
+
+You can remove a device from the integrations device list or the device page itself. It will no longer be reported to HA or be visible in the Heatmiser App. If you remove it, you will need to re-add it using the Heatmiser App or using the pairing instructions above.
+
+If a device is removed using the Heatmiser App or other external method, it will automatically be removed from the integration.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 20251119
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/311 by @ocrease, Use standard HA remove device option and automatically add new devices
+
 ## 20251118
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/310 by @ocrease, improve device removal flow

--- a/docs/repeaters.md
+++ b/docs/repeaters.md
@@ -5,4 +5,4 @@ nav_order: 5
 
 # Repeaters usage guide
 
-There is not a lot you can do with a repeater. It shows whether it is connected, and you can remove it from the hub. The Remove button is disabled by default. If you remove it, you will need to re-add it using the Heatmiser App or using the [advanced](advanced) configuration flow.
+There is not a lot you can do with a repeater. It shows whether it is connected. You can remove it from the hub following the [advanced](advanced) instructions.

--- a/docs/stat.md
+++ b/docs/stat.md
@@ -50,7 +50,6 @@ There are three preset modes:
 - Device Temperature - NeoStats in TimeClock mode still have access to the temperature
 - Identify - A button to flash the screen of a NeoStat in TimeClock mode
 - Floor Limit Reached - shows if the output is off because the floor limit temperature has been reached
-- Remove - A button to remove the device from the hub. It will no longer be reported to HA or be visible in the Heatmiser App. If you remove it, you will need to re-add it using the Heatmiser App or using the [advanced](advanced) configuration flow.
 
 # Configuration Options
 

--- a/docs/timeclock.md
+++ b/docs/timeclock.md
@@ -50,7 +50,6 @@ NeoPlugs are similar to TimeClocks, but have the ability to be set to ON or OFF 
 - Away - if the hub is away or on holiday
 - Device Temperature - NeoStats in TimeClock mode still have access to the temperature
 - Identify - A button to flash the screen of a NeoStat in TimeClock mode
-- Remove - A button to remove the device from the hub. It will no longer be reported to HA or be visible in the Heatmiser App. If you remove it, you will need to re-add it using the Heatmiser App or using the [advanced](advanced) configuration flow.
 
 # Configuration Options
 


### PR DESCRIPTION
Further improvements for #205 

- Use the standard HA feature to remove a device
  - Remove buttons no longer exist
- If a device is added via some other route (eg the Heatmiser App), automatically add the device to the integration