### PR TITLE
Add support for NeoHub V3

### DIFF
--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -122,6 +122,9 @@ HEATMISER_HUB_PRODUCT_LIST = [
     "NeoHub Version 1",
     "NeoHub Version 2",
     "NeoHub Mini",
+    "PLACEHOLDER-4",
+    "PLACEHOLDER-5",
+    "NeoHub Version 3",
 ]
 
 HEATMISER_PRODUCT_LIST = [


### PR DESCRIPTION
This adds support for the Neo Hub v3.

This follows on from #320, and explains why most of the entities were missing on the stats.

<img width="427" height="135" alt="image" src="https://github.com/user-attachments/assets/2adfbb15-3d86-43d9-acee-4b14c22985b5" />

Here is my [diagnostics output](https://github.com/user-attachments/files/24109707/diagnostics.json)