### PR TITLE
fix: handle '24:0' as a valid empty time sentinel

### DIFF
--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -153,8 +153,8 @@ def _heating_level_filter(level: TemperatureProfileLevel):
     return True
 
 
-def _is_valid_time(time) -> bool:
-    return not (time == "24:00" or time > "24:00")
+def _is_valid_time(time: str) -> bool:
+    return not (time.startswith("24:") or time > "24:00")
 
 
 def _flatten_timer_levels(


### PR DESCRIPTION
My Neohub V2 seems to return '24:0' instead of '24:00' for empty profile slots.

This inconsistency was causing a ValueError in strptime when calculating next profile times and a toast in the Heatmiser UI, as '24:0' was not being correctly caught by the existing validation logic.

This PR updates `helpers._is_valid_time` to catch any time string starting with '24:', ensuring all variations of the "empty" sentinel are handled correctly.

Happy to change it to catch just "24:0" if the `startswith(¨24:")` is considered too broad