### PR TITLE
Normalize profile times

### DIFF
--- a/custom_components/heatmiserneo/const.py
+++ b/custom_components/heatmiserneo/const.py
@@ -153,7 +153,7 @@ HEATMISER_PRODUCT_LIST = [
     "PLACEHOLDER-22",
     "NeoStat Touch",
     "NeoStat V3",
-    "NeoFlo"
+    "NeoFlo",
 ]
 
 HEATMISER_TYPE_IDS_THERMOSTAT = {1, 2, 7, 8, 9, 11, 12, 13, 15, 17, 19, 23, 24, 25}

--- a/custom_components/heatmiserneo/helpers.py
+++ b/custom_components/heatmiserneo/helpers.py
@@ -111,31 +111,39 @@ def _profile_levels(
         info = profile.profiles[0]
     key_val = key.value
     tmpLevels = getattr(info, key_val)
-    levels: list[ProfileLevel]
+    levels: list[ProfileLevel] = []
     if timeclock:
-        timerLevels = [
-            RawTimerProfileLevel(time=lv[0], end_time=lv[1])
-            for lv in tmpLevels.__dict__.values()
-        ]
-        levels = [lv for lv in timerLevels if filter(lv)]
+        for tl in tmpLevels.__dict__.values():
+            time = _normalize_time(tl[0])
+            end_time = _normalize_time(tl[1])
+            if time and end_time:
+                lv = RawTimerProfileLevel(time=time, end_time=end_time)
+                if filter(lv):
+                    levels.append(lv)
     else:
-        temperatureLevels = [
-            TemperatureProfileLevel(time=lv[0], temperature=float(lv[1]))
-            if len(lv) == 2
-            else HeatCoolTemperatureProfileLevel(
-                time=lv[0],
-                temperature=float(lv[1]),
-                cool_temperature=float(lv[2]),
-                enabled=bool(lv[3]),
-            )
-            for lv in tmpLevels.__dict__.values()
-        ]
-        levels = [lv for lv in temperatureLevels if filter(lv)]
+        for tl in tmpLevels.__dict__.values():
+            time = _normalize_time(tl[0])
+            if not time:
+                continue
+            temperature = float(tl[1])
+            if len(tl) == 4:
+                cool_temperature = float(tl[2])
+                enabled = bool(tl[3])
+                lv = HeatCoolTemperatureProfileLevel(
+                    time=time,
+                    temperature=temperature,
+                    cool_temperature=cool_temperature,
+                    enabled=enabled,
+                )
+            else:
+                lv = TemperatureProfileLevel(time=time, temperature=temperature)
+            if filter(lv):
+                levels.append(lv)
     return sorted(levels, key=lambda lv: lv.time)
 
 
 def _timer_level_filter(level: RawTimerProfileLevel):
-    if not _is_valid_time(level.time):
+    if not level.time:
         return False
     if level.time == level.end_time:
         return False
@@ -143,7 +151,7 @@ def _timer_level_filter(level: RawTimerProfileLevel):
 
 
 def _heating_level_filter(level: TemperatureProfileLevel):
-    if not _is_valid_time(level.time):
+    if not level.time:
         return False
     if level.temperature < 5:
         return False
@@ -153,8 +161,29 @@ def _heating_level_filter(level: TemperatureProfileLevel):
     return True
 
 
-def _is_valid_time(time) -> bool:
-    return not (time == "24:00" or time > "24:00")
+def _normalize_time(time: str | None) -> str | None:
+    """Normalize a time string to 'hh:mm' format (24-hour) or return None if invalid."""
+    if time is None:
+        return None
+
+    time = time.strip()
+    if not time:
+        return None
+
+    parts = time.split(":")
+    if len(parts) != 2:
+        return None
+
+    try:
+        hours = int(parts[0])
+        minutes = int(parts[1])
+    except ValueError:
+        return None
+
+    if not (0 <= hours <= 23 and 0 <= minutes <= 59):
+        return None
+
+    return f"{hours:02d}:{minutes:02d}"
 
 
 def _flatten_timer_levels(
@@ -345,64 +374,59 @@ def get_profile_definition(
 
     if timer:
         if friendly_mode:
-            levels = {
-                wd: [
-                    {"time_on": e[0], "time_off": e[1]}
-                    for e in sorted(lv.values(), key=lambda x: x[0])
-                    if _is_valid_time(e[0])
-                ]
-                for wd, lv in info.items()
-            }
+            levels = {}
+            for wd, lv in info.items():
+                levels[wd] = []
+                for e in sorted(lv.values(), key=lambda x: x[0]):
+                    start_time = _normalize_time(e[0])
+                    end_time = _normalize_time(e[1])
+                    if start_time and end_time:
+                        levels[wd].append(
+                            {"start_time": start_time, "end_time": end_time}
+                        )
 
             result["info"] = levels
         else:
-            on_times = {
-                wd + "_on_times": [
-                    e[0]
-                    for e in sorted(lv.values(), key=lambda x: x[0])
-                    if _is_valid_time(e[0])
-                ]
-                for wd, lv in info.items()
-            }
-            off_times = {
-                wd + "_off_times": [
-                    e[1]
-                    for e in sorted(lv.values(), key=lambda x: x[0])
-                    if _is_valid_time(e[0])
-                ]
-                for wd, lv in info.items()
-            }
+            on_times = {}
+            off_times = {}
+            for wd, lv in info.items():
+                on_list = []
+                off_list = []
+                for e in sorted(lv.values(), key=lambda x: x[0]):
+                    start_time = _normalize_time(e[0])
+                    end_time = _normalize_time(e[1])
+                    if start_time and end_time:
+                        on_list.append(start_time)
+                        off_list.append(end_time)
+                on_times[wd + "_on_times"] = on_list
+                off_times[wd + "_off_times"] = off_list
             times = on_times | off_times
             times = dict(sorted(times.items(), reverse=True))
 
             result = result | times
     elif friendly_mode:
-        levels = {
-            wd: [
-                {"time": e[0], "temperature": e[1]}
-                for e in sorted(lv.values(), key=lambda x: x[0])
-                if _is_valid_time(e[0])
-            ]
-            for wd, lv in info.items()
-        }
+        levels = {}
+        for wd, lv in info.items():
+            levels[wd] = []
+            for e in sorted(lv.values(), key=lambda x: x[0]):
+                time = _normalize_time(e[0])
+                if time:
+                    levels[wd].append({"time": time, "temperature": e[1]})
         result["info"] = levels
     else:
-        times = {
-            wd + "_times": [
-                e[0]
-                for e in sorted(lv.values(), key=lambda x: x[0])
-                if _is_valid_time(e[0])
-            ]
-            for wd, lv in info.items()
-        }
-        temperatures = {
-            wd + "_temperatures": [
-                e[1]
-                for e in sorted(lv.values(), key=lambda x: x[0])
-                if _is_valid_time(e[0])
-            ]
-            for wd, lv in info.items()
-        }
+        times = {}
+        temperatures = {}
+        for wd, lv in info.items():
+            times_list = []
+            temperatures_list = []
+            for e in sorted(lv.values(), key=lambda x: x[0]):
+                time = _normalize_time(e[0])
+                if time:
+                    times_list.append(time)
+                    temperatures_list.append(e[1])
+            times[wd + "_times"] = times_list
+            temperatures[wd + "_temperatures"] = temperatures_list
+
         levels = times | temperatures
         levels = dict(sorted(levels.items(), reverse=True))
         result = result | levels

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 20260125
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/328 by @ocrease, improve normalization of profile times
+
+## 20260115
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/326 by @ocrease, add support for NeoFlo
+
 ## 20251211
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/321 by @patch0, add support for NeoHub V3


### PR DESCRIPTION
Issue reported in #327. User's hub reports profile times such as 6:0 (rather than 06:00) and 24:0 (rather than 24:00). This PR improves handling of such times. For 6:0 which was previously filtered out, it will now be interpreted as 06:00. For 24:0 which was causing an error, this will now be correctly filtered out the same as 24:00