### PR TITLE
Issue 351 - attempt to get the mac address using targetted hubseek

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.16.5
     hooks:
       - id: ruff-check
         args:
@@ -8,7 +8,7 @@ repos:
       - id: ruff-format
         files: ^((custom_components)/.+)?[^/]+\.(py|pyi)$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
         args:

--- a/custom_components/heatmiserneo/config_flow.py
+++ b/custom_components/heatmiserneo/config_flow.py
@@ -71,6 +71,7 @@ from .const import (
 )
 from .coordinator import HeatmiserNeoConfigEntry
 from .discovery import (
+    async_discover_device,
     async_discover_device_connection_details,
     async_discover_devices,
     async_update_entry_from_discovery,
@@ -105,8 +106,15 @@ class FlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle zeroconf discovery."""
         _LOGGER.debug("Zeroconfig discovered %s", discovery_info)
 
+        neo_hub_details = await async_discover_device(self.hass, discovery_info.host)
+
         self._discovered_device = NeoHubDetails(
-            discovery_info.properties.get(ATTR_PROPERTIES_ID), discovery_info.host
+            neo_hub_details.mac_address
+            if neo_hub_details
+            else discovery_info.properties.get(
+                ATTR_PROPERTIES_ID,
+            ),
+            discovery_info.host,
         )
         _LOGGER.debug(
             "NeoHub discovered from zeroconf discovery: %s", self._discovered_device

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,14 @@
 # Change Log
 
-## 20260520
+## 20260624
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/352 by @ocrease, fix ZeroConf discovery MAC address mismatch
+
+## 20260624
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/349 by @ocrease, fix frost protection check for NeoStat HC
+
+## 20260608
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/344 by @ocrease, fix deprecation warning for entity registry values not being strings (sw_version and model_id)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -55,12 +55,12 @@ ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
     port=80,
     type="_hap._tcp.local.",
     properties={
-        "id": "aa:bb:cc:dd:ee:ff",
+        "id": "xx:xx:xx:xx:xx:xx",
     },
 )
 
 INTEGRATION_DISCOVERY: DiscoveryInfoType = {
-    "mac_address": ZEROCONF_DISCOVERY.properties.get("id"),
+    "mac_address": "aa:bb:cc:dd:ee:ff",
     "ip_address": "192.168.1.100",
 }
 
@@ -192,11 +192,21 @@ async def test_zeroconf_discovery(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf discovery."""
-    conn_menu_step = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=ZEROCONF_DISCOVERY,
-    )
+    with (
+        patch(
+            "custom_components.heatmiserneo.config_flow.async_discover_device",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    mac_address=INTEGRATION_DISCOVERY["mac_address"]
+                )
+            ),
+        ),
+    ):
+        conn_menu_step = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
 
     assert conn_menu_step["type"] is FlowResultType.MENU
     assert conn_menu_step["step_id"] == "choose_conn_method"
@@ -218,7 +228,7 @@ async def test_zeroconf_discovery(
         mock_hub_instance.firmware = AsyncMock(
             return_value=None
         )  # Assume firmware returns nothing specific; adjust if it returns data
-        mock_mac = ZEROCONF_DISCOVERY.properties.get("id")
+        mock_mac = INTEGRATION_DISCOVERY["mac_address"]
         mock_hub_instance.mac_address = mock_mac  # Fake MAC for unique_id
         mock_hub_instance.disconnect = AsyncMock(return_value=None)
         mock_hub_instance.get_all_live_data = AsyncMock(return_value=None)
@@ -245,11 +255,21 @@ async def test_zeroconf_discovery_connect_mismatch(
     hass: HomeAssistant,
 ) -> None:
     """Test zeroconf discovery."""
-    conn_menu_step = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=ZEROCONF_DISCOVERY,
-    )
+    with (
+        patch(
+            "custom_components.heatmiserneo.config_flow.async_discover_device",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    mac_address=INTEGRATION_DISCOVERY["mac_address"]
+                )
+            ),
+        ),
+    ):
+        conn_menu_step = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
 
     assert conn_menu_step["type"] is FlowResultType.MENU
     assert conn_menu_step["step_id"] == "choose_conn_method"
@@ -314,7 +334,7 @@ async def test_integration_discovery_using_legacy(
         mock_hub_instance.firmware = AsyncMock(
             return_value=None
         )  # Assume firmware returns nothing specific; adjust if it returns data
-        mock_mac = ZEROCONF_DISCOVERY.properties.get("id")
+        mock_mac = INTEGRATION_DISCOVERY["mac_address"]
         mock_hub_instance.mac_address = None
         mock_hub_instance.disconnect = AsyncMock(return_value=None)
         mock_hub_instance.get_all_live_data = AsyncMock(return_value=None)
@@ -376,7 +396,7 @@ async def test_options_flow(hass: HomeAssistant, config_entry: ConfigEntry) -> N
         assert defaults_form["type"] is FlowResultType.FORM
         assert defaults_form["step_id"] == CONF_DEFAULTS
 
-        UPDATE_OPTIONS = {
+        update_options = {
             CONF_THERMOSTAT_OPTIONS: {
                 CONF_STAT_HOLD_TEMP: 2,
                 CONF_STAT_HOLD_DURATION: {"minutes": 30},
@@ -387,7 +407,7 @@ async def test_options_flow(hass: HomeAssistant, config_entry: ConfigEntry) -> N
         }
 
         result2 = await hass.config_entries.options.async_configure(
-            defaults_form["flow_id"], UPDATE_OPTIONS
+            defaults_form["flow_id"], update_options
         )
         assert result2["type"] is FlowResultType.CREATE_ENTRY
         assert result2["data"] == {


### PR DESCRIPTION
Fix for #351 - ZeroConf diecovery ID is not a MAC address. Use the hubseek protocol to get the actual MAC address which is used as the unique id for the config entry