### PR TITLE
Fix via_device_id warning

### DIFF
--- a/custom_components/heatmiserneo/entity.py
+++ b/custom_components/heatmiserneo/entity.py
@@ -111,7 +111,11 @@ class HeatmiserNeoEntity[DescriptionT: HeatmiserNeoEntityDescription](
             suggested_area=self._neodevice.name,
             serial_number=self._neodevice.serial_number,
             sw_version=str(self._neodevice.stat_version),
-            via_device=(via_device_identifier_key, config_entry.unique_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (via_device_identifier_key, config_entry.unique_id),
+                config_entry_id=config_entry.entry_id,
+            ),
         )
 
     @property

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## 20260624
+## 20260909
+
+- Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/354 by @ocrease, fix via_device_id warning
+
+## 20260830
 
 - Merged https://github.com/MindrustUK/Heatmiser-for-home-assistant/pull/352 by @ocrease, fix ZeroConf discovery MAC address mismatch
 


### PR DESCRIPTION
Fix for warning that started appearing in HA 2026.9.0:

```Logger: homeassistant.helpers.frame
Source: helpers/frame.py:348
First occurred: 7 September 2026 at 22:53:04 (1 occurrence)
Last logged: 7 September 2026 at 22:53:04

Detected that custom integration 'heatmiserneo' calls `device_registry.async_get_or_create` with a deprecated `via_device` parameter; use `via_device_id` instead at custom_components/heatmiserneo/entity.py, line 293: async_add_entities(entities). This will stop working in Home Assistant 2027.8.0, please create a bug report at https://github.com/MindrustUK/Heatmiser-for-home-assistant/issues```